### PR TITLE
Match PS5 cloud entitlements by stable product ID prefix.

### DIFF
--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
@@ -63,10 +63,14 @@ object PsCloudOwnership
 			catalogMap[canonical]?.let { catalogMap[alias] = it }
 		}
 		val supplementMap = catalogMapFirstWins(plusLibrarySupplement)
+		val browseStableKey = buildStableKeyIndex(publicCatalog)
+		val supplementStableKey = buildStableKeyIndex(plusLibrarySupplement)
 		val byKey = linkedMapOf<String, CloudGame>()
 
 		for (ent in filteredEntitlements)
 		{
+			val stable = productIdStableKey(ent.productId)
+			val skipStableDemo = ent.name.contains("demo", ignoreCase = true)
 			val meta = when {
 				ent.productId.isNotEmpty() && catalogMap.containsKey(ent.productId) ->
 					catalogMap[ent.productId]
@@ -75,6 +79,10 @@ object PsCloudOwnership
 				ent.productId.isNotEmpty() && ent.id == ent.productId
 					&& supplementMap.containsKey(ent.productId) ->
 					supplementMap[ent.productId]
+				stable != null && !skipStableDemo && browseStableKey.containsKey(stable) ->
+					browseStableKey[stable]
+				stable != null && !skipStableDemo && supplementStableKey.containsKey(stable) ->
+					supplementStableKey[stable]
 				else -> null
 			} ?: continue
 
@@ -119,6 +127,37 @@ object PsCloudOwnership
 				map[game.productId] = game
 		}
 		return map
+	}
+
+	/** Tokenize on '-' and '_'; identity is all tokens except the last (store SKU). */
+	private fun productIdStableKey(productId: String): String?
+	{
+		if (productId.isEmpty())
+			return null
+		val tokens = mutableListOf<String>()
+		for (dashPart in productId.split('-'))
+		{
+			for (token in dashPart.split('_'))
+			{
+				if (token.isNotEmpty())
+					tokens.add(token)
+			}
+		}
+		if (tokens.size < 2)
+			return null
+		return tokens.dropLast(1).joinToString("|")
+	}
+
+	private fun buildStableKeyIndex(games: List<CloudGame>): Map<String, CloudGame>
+	{
+		val index = linkedMapOf<String, CloudGame>()
+		for (game in games)
+		{
+			val key = productIdStableKey(game.productId) ?: continue
+			if (key !in index)
+				index[key] = game
+		}
+		return index
 	}
 
 	fun mergeOwnedIntoBrowseCatalog(

--- a/gui/src/cloudcatalogbackend.cpp
+++ b/gui/src/cloudcatalogbackend.cpp
@@ -912,6 +912,39 @@ static QString ps5CloudConceptKey(const QJsonObject &gameObj)
     return gameObj.value(QStringLiteral("productId")).toString();
 }
 
+static QString ps5CloudProductIdStableKey(const QString &productId)
+{
+    if (productId.isEmpty())
+        return QString();
+    QStringList tokens;
+    const QStringList dashParts = productId.split(QLatin1Char('-'), Qt::SkipEmptyParts);
+    for (const QString &dashPart : dashParts) {
+        const QStringList underscoreParts = dashPart.split(QLatin1Char('_'), Qt::SkipEmptyParts);
+        for (const QString &token : underscoreParts)
+            tokens.append(token);
+    }
+    if (tokens.size() < 2)
+        return QString();
+    tokens.removeLast();
+    return tokens.join(QLatin1Char('|'));
+}
+
+static QMap<QString, QJsonObject> buildStableKeyIndex(const QJsonArray &games)
+{
+    QMap<QString, QJsonObject> index;
+    for (const QJsonValue &game : games) {
+        if (!game.isObject())
+            continue;
+        const QJsonObject gameObj = game.toObject();
+        const QString productId = gameObj.value(QStringLiteral("productId")).toString();
+        const QString key = ps5CloudProductIdStableKey(productId);
+        if (key.isEmpty() || index.contains(key))
+            continue;
+        index.insert(key, gameObj);
+    }
+    return index;
+}
+
 static QJsonObject productIdAliasesToJson(const QMap<QString, QString> &aliases)
 {
     QJsonObject obj;
@@ -2196,6 +2229,11 @@ void CloudCatalogBackend::processCrossReferenceComplete()
         }
     }
 
+    const QMap<QString, QJsonObject> browseStableKey =
+        buildStableKeyIndex(crossReferenceState.cloudCatalogGames);
+    const QMap<QString, QJsonObject> supplementStableKey =
+        buildStableKeyIndex(crossReferenceState.plusLibrarySupplement);
+
     if (settings && settings->GetLogVerbose()) {
         qInfo() << "[CROSS-REF] Cloud catalog map size:" << cloudCatalogMap.size();
         qInfo() << "[CROSS-REF] Product ID aliases:" << crossReferenceState.productIdAliases.size();
@@ -2208,6 +2246,8 @@ void CloudCatalogBackend::processCrossReferenceComplete()
     int productIdMatchCount = 0;
     int entitlementIdMatchCount = 0;
     int supplementMatchCount = 0;
+    int stableKeyBrowseMatchCount = 0;
+    int stableKeySupplementMatchCount = 0;
     QMap<QString, QJsonObject> ownedByKey;
 
     for (const QJsonValue &ownedGame : crossReferenceState.ownedGames) {
@@ -2217,6 +2257,10 @@ void CloudCatalogBackend::processCrossReferenceComplete()
         QJsonObject ownedGameObj = ownedGame.toObject();
         const QString productId = ownedGameObj.value(QStringLiteral("product_id")).toString();
         const QString entitlementId = ownedGameObj.value(QStringLiteral("id")).toString();
+        const QString entName = ownedGameObj.value(QStringLiteral("game_meta")).toObject()
+                                    .value(QStringLiteral("name")).toString();
+        const bool skipStableDemo = entName.contains(QStringLiteral("demo"), Qt::CaseInsensitive);
+        const QString stableKey = ps5CloudProductIdStableKey(productId);
 
         QJsonObject meta;
         bool found = false;
@@ -2236,6 +2280,16 @@ void CloudCatalogBackend::processCrossReferenceComplete()
             found = true;
             fromSupplement = true;
             supplementMatchCount++;
+        } else if (!stableKey.isEmpty() && !skipStableDemo && browseStableKey.contains(stableKey)) {
+            meta = browseStableKey.value(stableKey);
+            found = true;
+            stableKeyBrowseMatchCount++;
+        } else if (!stableKey.isEmpty() && !skipStableDemo
+                   && supplementStableKey.contains(stableKey)) {
+            meta = supplementStableKey.value(stableKey);
+            found = true;
+            fromSupplement = true;
+            stableKeySupplementMatchCount++;
         }
 
         if (!found)
@@ -2281,6 +2335,8 @@ void CloudCatalogBackend::processCrossReferenceComplete()
         qInfo() << "[CROSS-REF]   By product_id:" << productIdMatchCount;
         qInfo() << "[CROSS-REF]   By entitlement id (fallback):" << entitlementIdMatchCount;
         qInfo() << "[CROSS-REF]   By Plus library supplement:" << supplementMatchCount;
+        qInfo() << "[CROSS-REF]   By stable product id key (browse):" << stableKeyBrowseMatchCount;
+        qInfo() << "[CROSS-REF]   By stable product id key (supplement):" << stableKeySupplementMatchCount;
     }
 
     QJsonObject result;

--- a/ios/Pylux/Services/PsCloudOwnership.swift
+++ b/ios/Pylux/Services/PsCloudOwnership.swift
@@ -51,8 +51,13 @@ enum PsCloudOwnership {
             supplementMap[game.id] = game
         }
 
+        let browseStableKey = buildStableKeyIndex(publicCatalog)
+        let supplementStableKey = buildStableKeyIndex(plusLibrarySupplement)
+
         var byKey: [String: CloudGame] = [:]
         for ent in filteredEntitlements {
+            let stable = productIdStableKey(ent.productId)
+            let skipStableDemo = ent.name.localizedCaseInsensitiveContains("demo")
             let meta: CloudGame?
             if !ent.productId.isEmpty, let g = catalogMap[ent.productId] {
                 meta = g
@@ -60,6 +65,10 @@ enum PsCloudOwnership {
                 meta = g
             } else if !ent.productId.isEmpty, ent.id == ent.productId,
                       let g = supplementMap[ent.productId] {
+                meta = g
+            } else if let stable, !skipStableDemo, let g = browseStableKey[stable] {
+                meta = g
+            } else if let stable, !skipStableDemo, let g = supplementStableKey[stable] {
                 meta = g
             } else {
                 meta = nil
@@ -105,6 +114,30 @@ enum PsCloudOwnership {
             return candidate
         }
         return existing
+    }
+
+    /// Tokenize on '-' and '_'; identity is all tokens except the last (store SKU).
+    private static func productIdStableKey(_ productId: String) -> String? {
+        guard !productId.isEmpty else { return nil }
+        var tokens: [String] = []
+        for dashPart in productId.split(separator: "-") {
+            for token in dashPart.split(separator: "_") where !token.isEmpty {
+                tokens.append(String(token))
+            }
+        }
+        guard tokens.count >= 2 else { return nil }
+        return tokens.dropLast().joined(separator: "|")
+    }
+
+    private static func buildStableKeyIndex(_ games: [CloudGame]) -> [String: CloudGame] {
+        var index: [String: CloudGame] = [:]
+        for game in games {
+            guard let key = productIdStableKey(game.id) else { continue }
+            if index[key] == nil {
+                index[key] = game
+            }
+        }
+        return index
     }
 
     static func mergeOwnedIntoBrowseCatalog(


### PR DESCRIPTION
Edition SKUs often differ between entitlements and catalog (e.g. FF7 Rebirth). Fall back to stable-key lookup on browse catalog, then supplement, skipping demo titles.

Hopefully this fixes missing games issue!