### PR TITLE
Fix PS5 cloud ownership matching across Qt, iOS, and Android.

### DIFF
--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudCatalogService.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudCatalogService.kt
@@ -315,10 +315,16 @@ class PsCloudCatalogService
 		kotlinx.coroutines.delay(PsCloudOwnership.PAGE_COOLDOWN_MS)
 		
 		val rawEntitlements = fetchEntitlementsPaginated(oauthToken)
+		val componentIdsByProductId = HashMap<String, MutableList<String>>()
+		for (e in rawEntitlements)
+		{
+			if (e.productId.isNotEmpty() && e.id.isNotEmpty())
+				componentIdsByProductId.getOrPut(e.productId) { mutableListOf() }.add(e.id)
+		}
 		val filtered = PsCloudOwnership.filterOwnedPs5Games(rawEntitlements)
 		
 		return PsCloudOwnership.crossReferenceOwnedGames(
-			filtered, publicCatalog, plusLibrarySupplement, productIdAliases
+			filtered, publicCatalog, plusLibrarySupplement, productIdAliases, componentIdsByProductId
 		)
 	}
 	

--- a/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/cloudplay/api/PsCloudOwnership.kt
@@ -53,6 +53,7 @@ object PsCloudOwnership
 		publicCatalog: List<CloudGame>,
 		plusLibrarySupplement: List<CloudGame> = emptyList(),
 		productIdAliases: Map<String, String> = emptyMap(),
+		componentIdsByProductId: Map<String, List<String>> = emptyMap(),
 	): List<CloudGame>
 	{
 		val catalogMap = catalogMapFirstWins(publicCatalog)
@@ -67,25 +68,8 @@ object PsCloudOwnership
 		val supplementStableKey = buildStableKeyIndex(plusLibrarySupplement)
 		val byKey = linkedMapOf<String, CloudGame>()
 
-		for (ent in filteredEntitlements)
+		fun emitMatch(meta: CloudGame, ent: Entitlement)
 		{
-			val stable = productIdStableKey(ent.productId)
-			val skipStableDemo = ent.name.contains("demo", ignoreCase = true)
-			val meta = when {
-				ent.productId.isNotEmpty() && catalogMap.containsKey(ent.productId) ->
-					catalogMap[ent.productId]
-				ent.id.isNotEmpty() && catalogMap.containsKey(ent.id) ->
-					catalogMap[ent.id]
-				ent.productId.isNotEmpty() && ent.id == ent.productId
-					&& supplementMap.containsKey(ent.productId) ->
-					supplementMap[ent.productId]
-				stable != null && !skipStableDemo && browseStableKey.containsKey(stable) ->
-					browseStableKey[stable]
-				stable != null && !skipStableDemo && supplementStableKey.containsKey(stable) ->
-					supplementStableKey[stable]
-				else -> null
-			} ?: continue
-
 			val displayName = meta.name.ifEmpty { ent.name }
 			val game = meta.copy(
 				name = displayName,
@@ -96,6 +80,72 @@ object PsCloudOwnership
 			val key = ownedDedupeKey(meta, ent)
 			val existing = byKey[key]
 			byKey[key] = if (existing == null) game else preferOwnedEntry(existing, game)
+		}
+
+		for (ent in filteredEntitlements)
+		{
+			val skipStableDemo = ent.name.contains("demo", ignoreCase = true)
+			val matches = mutableListOf<CloudGame>()
+
+			if (ent.productId.isNotEmpty() && catalogMap.containsKey(ent.productId))
+			{
+				matches.add(catalogMap.getValue(ent.productId))
+			}
+			else if (ent.id.isNotEmpty() && catalogMap.containsKey(ent.id))
+			{
+				matches.add(catalogMap.getValue(ent.id))
+			}
+			else if (ent.productId.isNotEmpty() && ent.id == ent.productId
+				&& supplementMap.containsKey(ent.productId))
+			{
+				matches.add(supplementMap.getValue(ent.productId))
+			}
+			else
+			{
+				val entitlementStableKey = productIdStableKey(ent.id)
+				if (entitlementStableKey != null && !skipStableDemo
+					&& browseStableKey.containsKey(entitlementStableKey))
+				{
+					matches.add(browseStableKey.getValue(entitlementStableKey))
+				}
+				else if (entitlementStableKey != null && !skipStableDemo
+					&& supplementStableKey.containsKey(entitlementStableKey))
+				{
+					matches.add(supplementStableKey.getValue(entitlementStableKey))
+				}
+			}
+
+			if (matches.isEmpty())
+			{
+				val seenProductIds = mutableSetOf<String>()
+				for (siblingId in componentIdsByProductId[ent.productId].orEmpty())
+				{
+					val siblingMeta = when
+					{
+						catalogMap.containsKey(siblingId) -> catalogMap[siblingId]
+						supplementMap.containsKey(siblingId) -> supplementMap[siblingId]
+						else ->
+						{
+							val siblingStableKey = productIdStableKey(siblingId)
+							if (siblingStableKey != null && !skipStableDemo)
+								browseStableKey[siblingStableKey]
+									?: supplementStableKey[siblingStableKey]
+							else
+								null
+						}
+					} ?: continue
+					if (siblingMeta.productId.isEmpty() || siblingMeta.productId in seenProductIds)
+						continue
+					seenProductIds.add(siblingMeta.productId)
+					matches.add(siblingMeta)
+				}
+			}
+
+			if (matches.isEmpty())
+				continue
+
+			for (meta in matches)
+				emitMatch(meta, ent)
 		}
 
 		return byKey.values.toList()

--- a/gui/include/cloudcatalogbackend.h
+++ b/gui/include/cloudcatalogbackend.h
@@ -132,6 +132,7 @@ private:
         QJsonArray plusLibrarySupplement;
         QJsonArray ownedGames;
         QMap<QString, QString> productIdAliases;
+        QMap<QString, QStringList> componentIdsByProductId; // product_id -> all sibling entitlement ids (full list)
         bool catalogFetched;
         bool ownedGamesFetched;
     } crossReferenceState;

--- a/gui/src/cloudcatalogbackend.cpp
+++ b/gui/src/cloudcatalogbackend.cpp
@@ -67,6 +67,7 @@ CloudCatalogBackend::CloudCatalogBackend(Settings *settings, QObject *parent)
     crossReferenceState.plusLibrarySupplement = QJsonArray();
     crossReferenceState.ownedGames = QJsonArray();
     crossReferenceState.productIdAliases.clear();
+    crossReferenceState.componentIdsByProductId.clear();
     crossReferenceState.catalogFetched = false;
     crossReferenceState.ownedGamesFetched = false;
 }
@@ -1523,6 +1524,17 @@ void CloudCatalogBackend::handleOwnedGamesResponse()
     
     // Filter for PS5 games (package_type=PSGD)
     QJsonArray ps5Games = filterOwnedPs5Games(ownedGamesState.accumulatedEntitlements);
+
+    QMap<QString, QStringList> componentIds;
+    for (const QJsonValue &ent : ownedGamesState.accumulatedEntitlements) {
+        if (!ent.isObject())
+            continue;
+        const QJsonObject o = ent.toObject();
+        const QString pid = o.value(QStringLiteral("product_id")).toString();
+        const QString eid = o.value(QStringLiteral("id")).toString();
+        if (!pid.isEmpty() && !eid.isEmpty())
+            componentIds[pid].append(eid);
+    }
     
     if (settings && settings->GetLogVerbose()) {
         qInfo() << "  PS5 games (PSGD):" << ps5Games.size();
@@ -1531,6 +1543,10 @@ void CloudCatalogBackend::handleOwnedGamesResponse()
     QJsonObject result;
     result["games"] = ps5Games;
     result["total"] = ps5Games.size();
+    QJsonObject componentObj;
+    for (auto it = componentIds.cbegin(); it != componentIds.cend(); ++it)
+        componentObj.insert(it.key(), QJsonArray::fromStringList(it.value()));
+    result[QStringLiteral("componentIdsByProductId")] = componentObj;
     
     QJsonDocument resultDoc(result);
     
@@ -1540,6 +1556,7 @@ void CloudCatalogBackend::handleOwnedGamesResponse()
     // If cross-reference is active, populate its state
     if (crossReferenceState.callback.isCallable() && !crossReferenceState.ownedGamesFetched) {
         crossReferenceState.ownedGames = ps5Games;
+        crossReferenceState.componentIdsByProductId = componentIds;
         crossReferenceState.ownedGamesFetched = true;
         if (settings && settings->GetLogVerbose()) {
             qInfo() << "[CROSS-REF] Fetched owned PS5 games from API:" << ps5Games.size() << "games";
@@ -1648,6 +1665,7 @@ void CloudCatalogBackend::getOwnedPs5CloudGames(const QJSValue &callback)
     crossReferenceState.plusLibrarySupplement = QJsonArray();
     crossReferenceState.ownedGames = QJsonArray();
     crossReferenceState.productIdAliases.clear();
+    crossReferenceState.componentIdsByProductId.clear();
     crossReferenceState.catalogFetched = false;
     crossReferenceState.ownedGamesFetched = false;
     
@@ -1702,6 +1720,17 @@ void CloudCatalogBackend::getOwnedPs5CloudGames(const QJSValue &callback)
                 crossReferenceState.ownedGamesFetched = true;
                 if (settings && settings->GetLogVerbose()) {
                     qInfo() << "[CROSS-REF] Loaded owned PS5 games from cache:" << crossReferenceState.ownedGames.size() << "games";
+                }
+            }
+            if (obj.contains(QStringLiteral("componentIdsByProductId"))
+                && obj.value(QStringLiteral("componentIdsByProductId")).isObject()) {
+                const QJsonObject m = obj.value(QStringLiteral("componentIdsByProductId")).toObject();
+                crossReferenceState.componentIdsByProductId.clear();
+                for (auto it = m.begin(); it != m.end(); ++it) {
+                    QStringList ids;
+                    for (const QJsonValue &v : it.value().toArray())
+                        ids.append(v.toString());
+                    crossReferenceState.componentIdsByProductId.insert(it.key(), ids);
                 }
             }
         }
@@ -2243,11 +2272,10 @@ void CloudCatalogBackend::processCrossReferenceComplete()
 
     QJsonArray filteredGames;
     int matchedCount = 0;
-    int productIdMatchCount = 0;
-    int entitlementIdMatchCount = 0;
-    int supplementMatchCount = 0;
-    int stableKeyBrowseMatchCount = 0;
-    int stableKeySupplementMatchCount = 0;
+    int t1Count = 0;
+    int t2Count = 0;
+    int t3Count = 0;
+    int t4Count = 0;
     QMap<QString, QJsonObject> ownedByKey;
 
     for (const QJsonValue &ownedGame : crossReferenceState.ownedGames) {
@@ -2260,71 +2288,138 @@ void CloudCatalogBackend::processCrossReferenceComplete()
         const QString entName = ownedGameObj.value(QStringLiteral("game_meta")).toObject()
                                     .value(QStringLiteral("name")).toString();
         const bool skipStableDemo = entName.contains(QStringLiteral("demo"), Qt::CaseInsensitive);
-        const QString stableKey = ps5CloudProductIdStableKey(productId);
 
-        QJsonObject meta;
-        bool found = false;
-        bool fromSupplement = false;
+        QList<QPair<QJsonObject, bool>> matches;
+        int matchTier = 0;
 
         if (!productId.isEmpty() && cloudCatalogMap.contains(productId)) {
-            meta = cloudCatalogMap.value(productId);
-            found = true;
-            productIdMatchCount++;
+            matches.append({cloudCatalogMap.value(productId), false});
+            matchTier = 1;
         } else if (!entitlementId.isEmpty() && cloudCatalogMap.contains(entitlementId)) {
-            meta = cloudCatalogMap.value(entitlementId);
-            found = true;
-            entitlementIdMatchCount++;
+            matches.append({cloudCatalogMap.value(entitlementId), false});
+            matchTier = 2;
         } else if (!productId.isEmpty() && !entitlementId.isEmpty()
                    && entitlementId == productId && plusSupplementMap.contains(productId)) {
-            meta = plusSupplementMap.value(productId);
-            found = true;
-            fromSupplement = true;
-            supplementMatchCount++;
-        } else if (!stableKey.isEmpty() && !skipStableDemo && browseStableKey.contains(stableKey)) {
-            meta = browseStableKey.value(stableKey);
-            found = true;
-            stableKeyBrowseMatchCount++;
-        } else if (!stableKey.isEmpty() && !skipStableDemo
-                   && supplementStableKey.contains(stableKey)) {
-            meta = supplementStableKey.value(stableKey);
-            found = true;
-            fromSupplement = true;
-            stableKeySupplementMatchCount++;
+            matches.append({plusSupplementMap.value(productId), true});
+            matchTier = 2;
+        } else {
+            const QString entitlementStableKey = ps5CloudProductIdStableKey(entitlementId);
+            if (!entitlementStableKey.isEmpty() && !skipStableDemo
+                && browseStableKey.contains(entitlementStableKey)) {
+                matches.append({browseStableKey.value(entitlementStableKey), false});
+                matchTier = 3;
+            } else if (!entitlementStableKey.isEmpty() && !skipStableDemo
+                       && supplementStableKey.contains(entitlementStableKey)) {
+                matches.append({supplementStableKey.value(entitlementStableKey), true});
+                matchTier = 3;
+            }
         }
 
-        if (!found)
+        if (matches.isEmpty()) {
+            QSet<QString> seenProductIds;
+            for (const QString &siblingId :
+                 crossReferenceState.componentIdsByProductId.value(productId)) {
+                QJsonObject siblingMeta;
+                bool siblingFromSupplement = false;
+                if (cloudCatalogMap.contains(siblingId)) {
+                    siblingMeta = cloudCatalogMap.value(siblingId);
+                } else if (plusSupplementMap.contains(siblingId)) {
+                    siblingMeta = plusSupplementMap.value(siblingId);
+                    siblingFromSupplement = true;
+                } else {
+                    const QString siblingStableKey = ps5CloudProductIdStableKey(siblingId);
+                    if (!siblingStableKey.isEmpty() && !skipStableDemo) {
+                        if (browseStableKey.contains(siblingStableKey)) {
+                            siblingMeta = browseStableKey.value(siblingStableKey);
+                        } else if (supplementStableKey.contains(siblingStableKey)) {
+                            siblingMeta = supplementStableKey.value(siblingStableKey);
+                            siblingFromSupplement = true;
+                        }
+                    }
+                }
+                if (siblingMeta.isEmpty())
+                    continue;
+                const QString matchedPid =
+                    siblingMeta.value(QStringLiteral("productId")).toString();
+                if (matchedPid.isEmpty() || seenProductIds.contains(matchedPid))
+                    continue;
+                seenProductIds.insert(matchedPid);
+                matches.append({siblingMeta, siblingFromSupplement});
+            }
+            if (!matches.isEmpty())
+                matchTier = 4;
+        }
+
+        if (matches.isEmpty())
             continue;
 
-        if (meta.contains(QStringLiteral("name"))) {
-            const QString imagicName = meta.value(QStringLiteral("name")).toString();
-            if (!imagicName.isEmpty())
-                ownedGameObj.insert(QStringLiteral("name"), imagicName);
+        switch (matchTier) {
+        case 1: t1Count++; break;
+        case 2: t2Count++; break;
+        case 3: t3Count++; break;
+        case 4: t4Count++; break;
+        default: break;
         }
-        if (meta.contains(QStringLiteral("imageUrl"))
-            && !meta.value(QStringLiteral("imageUrl")).toString().isEmpty()) {
-            ownedGameObj.insert(QStringLiteral("imageUrl"), meta.value(QStringLiteral("imageUrl")));
-        }
-        if (meta.contains(QStringLiteral("conceptUrl"))) {
-            ownedGameObj.insert(QStringLiteral("conceptUrl"), meta.value(QStringLiteral("conceptUrl")));
-        }
-        ownedGameObj.insert(QStringLiteral("productId"), productId);
-        ownedGameObj.insert(QStringLiteral("streamingSupported"), !fromSupplement);
 
-        const QString conceptId = meta.value(QStringLiteral("conceptId")).toString();
-        const QString dedupeKey = !conceptId.isEmpty() ? QStringLiteral("c:") + conceptId
-                                : !productId.isEmpty() ? QStringLiteral("p:") + productId
-                                : !entitlementId.isEmpty() ? QStringLiteral("e:") + entitlementId
-                                : QStringLiteral("u:") + productId + QLatin1Char(':') + entitlementId;
+        for (const QPair<QJsonObject, bool> &match : matches) {
+            const QJsonObject meta = match.first;
+            const bool fromSupplement = match.second;
+            QJsonObject entry = ownedGameObj;
 
-        if (ownedByKey.contains(dedupeKey)) {
-            const QJsonObject existing = ownedByKey.value(dedupeKey);
-            const QString existingEntId = existing.value(QStringLiteral("id")).toString();
-            if (existingEntId.isEmpty() && !entitlementId.isEmpty())
-                ownedByKey.insert(dedupeKey, ownedGameObj);
-        } else {
-            ownedByKey.insert(dedupeKey, ownedGameObj);
+            if (meta.contains(QStringLiteral("name"))) {
+                const QString imagicName = meta.value(QStringLiteral("name")).toString();
+                if (!imagicName.isEmpty())
+                    entry.insert(QStringLiteral("name"), imagicName);
+            }
+            if (meta.contains(QStringLiteral("imageUrl"))
+                && !meta.value(QStringLiteral("imageUrl")).toString().isEmpty()) {
+                entry.insert(QStringLiteral("imageUrl"), meta.value(QStringLiteral("imageUrl")));
+            }
+            if (meta.contains(QStringLiteral("conceptUrl"))) {
+                entry.insert(QStringLiteral("conceptUrl"), meta.value(QStringLiteral("conceptUrl")));
+            }
+            // Identify the owned entry by the MATCHED CATALOG ROW (productId +
+            // conceptId) so the QML merge (findPs5CloudCatalogIndexForOwned) can
+            // link it back to the catalog card. Using the entitlement's bundle
+            // product_id here breaks T3/T4 matches whose entitlement id/product_id
+            // do not equal any catalog productId (e.g. RE7 base reached via the
+            // RE7 Gold bundle). The entitlement product_id is retained as
+            // storeProductId for streaming/store lookups.
+            const QString catalogProductId = meta.value(QStringLiteral("productId")).toString();
+            entry.insert(QStringLiteral("productId"),
+                         !catalogProductId.isEmpty() ? catalogProductId : productId);
+            entry.insert(QStringLiteral("storeProductId"), productId);
+
+            // conceptId may be a JSON number or string; normalize to a string.
+            const QJsonValue conceptVal = meta.value(QStringLiteral("conceptId"));
+            const QString conceptId = conceptVal.isString()
+                ? conceptVal.toString()
+                : (conceptVal.isDouble()
+                       ? QString::number(static_cast<qint64>(conceptVal.toDouble()))
+                       : QString());
+            if (!conceptId.isEmpty())
+                entry.insert(QStringLiteral("conceptId"), conceptId);
+            entry.insert(QStringLiteral("streamingSupported"), !fromSupplement);
+
+            // Dedupe by the MATCHED CATALOG identity (conceptId, then catalog
+            // productId). Using the entitlement product_id here collapses every
+            // bundle sibling (e.g. RE7 Gold -> RE7 base + Village) into a single
+            // entry, dropping all but the first match.
+            const QString dedupeKey = !conceptId.isEmpty() ? QStringLiteral("c:") + conceptId
+                                    : !catalogProductId.isEmpty() ? QStringLiteral("p:") + catalogProductId
+                                    : !entitlementId.isEmpty() ? QStringLiteral("e:") + entitlementId
+                                    : QStringLiteral("u:") + catalogProductId + QLatin1Char(':') + entitlementId;
+
+            if (ownedByKey.contains(dedupeKey)) {
+                const QJsonObject existing = ownedByKey.value(dedupeKey);
+                const QString existingEntId = existing.value(QStringLiteral("id")).toString();
+                if (existingEntId.isEmpty() && !entitlementId.isEmpty())
+                    ownedByKey.insert(dedupeKey, entry);
+            } else {
+                ownedByKey.insert(dedupeKey, entry);
+            }
+            matchedCount++;
         }
-        matchedCount++;
     }
 
     for (const QJsonObject &gameObj : ownedByKey)
@@ -2332,11 +2427,10 @@ void CloudCatalogBackend::processCrossReferenceComplete()
 
     if (settings && settings->GetLogVerbose()) {
         qInfo() << "[CROSS-REF] Matched games (cloud streamable):" << matchedCount;
-        qInfo() << "[CROSS-REF]   By product_id:" << productIdMatchCount;
-        qInfo() << "[CROSS-REF]   By entitlement id (fallback):" << entitlementIdMatchCount;
-        qInfo() << "[CROSS-REF]   By Plus library supplement:" << supplementMatchCount;
-        qInfo() << "[CROSS-REF]   By stable product id key (browse):" << stableKeyBrowseMatchCount;
-        qInfo() << "[CROSS-REF]   By stable product id key (supplement):" << stableKeySupplementMatchCount;
+        qInfo() << "[CROSS-REF]   T1 (product_id):" << t1Count;
+        qInfo() << "[CROSS-REF]   T2 (entitlement id):" << t2Count;
+        qInfo() << "[CROSS-REF]   T3 (stable key on id):" << t3Count;
+        qInfo() << "[CROSS-REF]   T4 (bundle siblings):" << t4Count;
     }
 
     QJsonObject result;
@@ -2355,6 +2449,7 @@ void CloudCatalogBackend::processCrossReferenceComplete()
     crossReferenceState.plusLibrarySupplement = QJsonArray();
     crossReferenceState.ownedGames = QJsonArray();
     crossReferenceState.productIdAliases.clear();
+    crossReferenceState.componentIdsByProductId.clear();
     crossReferenceState.catalogFetched = false;
     crossReferenceState.ownedGamesFetched = false;
 }

--- a/ios/Pylux/Services/CloudCatalogService.swift
+++ b/ios/Pylux/Services/CloudCatalogService.swift
@@ -466,13 +466,18 @@ final class CloudCatalogService {
             return nil
         }
         let rawEntitlements = rawObjects.compactMap { PsCloudOwnership.parseEntitlement($0) }
+        var componentIdsByProductId: [String: [String]] = [:]
+        for e in rawEntitlements where !e.productId.isEmpty && !e.id.isEmpty {
+            componentIdsByProductId[e.productId, default: []].append(e.id)
+        }
         let filtered = PsCloudOwnership.filterOwnedPs5Games(rawEntitlements)
 
         return PsCloudOwnership.crossReferenceOwnedGames(
             filteredEntitlements: filtered,
             publicCatalog: publicCatalog,
             plusLibrarySupplement: plusLibrarySupplement,
-            productIdAliases: productIdAliases
+            productIdAliases: productIdAliases,
+            componentIdsByProductId: componentIdsByProductId
         )
     }
 

--- a/ios/Pylux/Services/PsCloudOwnership.swift
+++ b/ios/Pylux/Services/PsCloudOwnership.swift
@@ -34,7 +34,8 @@ enum PsCloudOwnership {
         filteredEntitlements: [PsCloudEntitlement],
         publicCatalog: [CloudGame],
         plusLibrarySupplement: [CloudGame] = [],
-        productIdAliases: [String: String] = [:]
+        productIdAliases: [String: String] = [:],
+        componentIdsByProductId: [String: [String]] = [:]
     ) -> [CloudGame] {
         var catalogMap: [String: CloudGame] = [:]
         for game in publicCatalog {
@@ -55,29 +56,10 @@ enum PsCloudOwnership {
         let supplementStableKey = buildStableKeyIndex(plusLibrarySupplement)
 
         var byKey: [String: CloudGame] = [:]
-        for ent in filteredEntitlements {
-            let stable = productIdStableKey(ent.productId)
-            let skipStableDemo = ent.name.localizedCaseInsensitiveContains("demo")
-            let meta: CloudGame?
-            if !ent.productId.isEmpty, let g = catalogMap[ent.productId] {
-                meta = g
-            } else if !ent.id.isEmpty, let g = catalogMap[ent.id] {
-                meta = g
-            } else if !ent.productId.isEmpty, ent.id == ent.productId,
-                      let g = supplementMap[ent.productId] {
-                meta = g
-            } else if let stable, !skipStableDemo, let g = browseStableKey[stable] {
-                meta = g
-            } else if let stable, !skipStableDemo, let g = supplementStableKey[stable] {
-                meta = g
-            } else {
-                meta = nil
-            }
 
-            guard let meta else { continue }
-
+        func emitMatch(meta: CloudGame, ent: PsCloudEntitlement) {
             let displayName = meta.name.isEmpty ? ent.name : meta.name
-            var game = CloudGame(
+            let game = CloudGame(
                 productId: meta.id,
                 name: displayName,
                 imageUrl: meta.imageUrl,
@@ -96,6 +78,57 @@ enum PsCloudOwnership {
                 byKey[key] = preferOwnedEntry(existing: existing, candidate: game)
             } else {
                 byKey[key] = game
+            }
+        }
+
+        for ent in filteredEntitlements {
+            let skipStableDemo = ent.name.localizedCaseInsensitiveContains("demo")
+            var matches: [CloudGame] = []
+
+            if !ent.productId.isEmpty, let g = catalogMap[ent.productId] {
+                matches.append(g)
+            } else if !ent.id.isEmpty, let g = catalogMap[ent.id] {
+                matches.append(g)
+            } else if !ent.productId.isEmpty, ent.id == ent.productId,
+                      let g = supplementMap[ent.productId] {
+                matches.append(g)
+            } else {
+                let entitlementStableKey = productIdStableKey(ent.id)
+                if let entitlementStableKey, !skipStableDemo,
+                   let g = browseStableKey[entitlementStableKey] {
+                    matches.append(g)
+                } else if let entitlementStableKey, !skipStableDemo,
+                          let g = supplementStableKey[entitlementStableKey] {
+                    matches.append(g)
+                }
+            }
+
+            if matches.isEmpty {
+                var seenProductIds: Set<String> = []
+                for siblingId in componentIdsByProductId[ent.productId] ?? [] {
+                    let siblingMeta: CloudGame?
+                    if let g = catalogMap[siblingId] {
+                        siblingMeta = g
+                    } else if let g = supplementMap[siblingId] {
+                        siblingMeta = g
+                    } else if let siblingStableKey = productIdStableKey(siblingId), !skipStableDemo {
+                        siblingMeta = browseStableKey[siblingStableKey]
+                            ?? supplementStableKey[siblingStableKey]
+                    } else {
+                        siblingMeta = nil
+                    }
+
+                    guard let meta = siblingMeta else { continue }
+                    if meta.id.isEmpty || seenProductIds.contains(meta.id) { continue }
+                    seenProductIds.insert(meta.id)
+                    matches.append(meta)
+                }
+            }
+
+            if matches.isEmpty { continue }
+
+            for meta in matches {
+                emitMatch(meta: meta, ent: ent)
             }
         }
 


### PR DESCRIPTION
Complete the ownership cascade with stable-key matching on entitlement ids, bundle sibling expansion, and catalog-based emit/dedupe so owned games merge and stream with the correct entitlement id.