### PR TITLE
Fix 8 bugs + 10 cleanups from the cloud-provisioning review

### DIFF
--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -712,7 +712,8 @@ JNIEXPORT void JNICALL JNI_FCN(sessionSetSurface)(JNIEnv *env, jobject obj, jlon
 // them. Returns a double[7]:
 //   [0] bitrate (Mbit/s)   [1] packet loss (0..1)   [2] dropped frames (cumulative)
 //   [3] fps                [4] rtt (ms)             [5] width   [6] height
-// Cheap best-effort read with no locking (same as Qt's polling timer); only
+// Cheap best-effort read (same as Qt's polling timer); video_receiver-derived
+// values go through locked accessors, the rest are unlocked scalar reads. Only
 // called while a session is live and the overlay is toggled on.
 JNIEXPORT jdoubleArray JNICALL JNI_FCN(sessionGetMetrics)(JNIEnv *env, jobject obj, jlong ptr)
 {
@@ -725,9 +726,7 @@ JNIEXPORT jdoubleArray JNICALL JNI_FCN(sessionGetMetrics)(JNIEnv *env, jobject o
 		vals[1] = sc->congestion_control.packet_loss;
 		vals[3] = sc->measured_fps;
 		vals[4] = sc->measured_rtt_ms;
-		ChiakiVideoReceiver *vr = sc->video_receiver;
-		if(vr)
-			vals[2] = (jdouble)vr->cumulative_frames_lost;
+		vals[2] = (jdouble)chiaki_stream_connection_video_frames_lost(sc); // 0 when no receiver — same as the zero-initialized array
 		unsigned int vw = 0, vh = 0;
 		if(chiaki_stream_connection_video_resolution(sc, &vw, &vh))
 		{

--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -727,13 +727,12 @@ JNIEXPORT jdoubleArray JNICALL JNI_FCN(sessionGetMetrics)(JNIEnv *env, jobject o
 		vals[4] = sc->measured_rtt_ms;
 		ChiakiVideoReceiver *vr = sc->video_receiver;
 		if(vr)
-		{
 			vals[2] = (jdouble)vr->cumulative_frames_lost;
-			if(vr->profile_cur >= 0 && (size_t)vr->profile_cur < vr->profiles_count)
-			{
-				vals[5] = (jdouble)vr->profiles[vr->profile_cur].width;
-				vals[6] = (jdouble)vr->profiles[vr->profile_cur].height;
-			}
+		unsigned int vw = 0, vh = 0;
+		if(chiaki_stream_connection_video_resolution(sc, &vw, &vh))
+		{
+			vals[5] = (jdouble)vw;
+			vals[6] = (jdouble)vh;
 		}
 		// Fall back to the requested profile before the first adaptive profile is selected.
 		if(vals[5] == 0 || vals[6] == 0)

--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
@@ -1100,7 +1100,7 @@ class CloudPlayFragment : Fragment()
 					ownedEntitlementId = game.entitlementId,
 					ownedPlatform = game.platform,
 					onProgress = { message ->
-						requireActivity().runOnUiThread {
+						activity?.runOnUiThread {
 							allocationProgressTextView?.text = message
 						}
 					},

--- a/gui/include/cloudcatalogbackend.h
+++ b/gui/include/cloudcatalogbackend.h
@@ -63,7 +63,6 @@ public:
 
     // Utility methods
     Q_INVOKABLE void invalidateCache();
-    Q_INVOKABLE void invalidatePs5CatalogCache();
     Q_INVOKABLE QString getCachedData(const QString &key, int maxAge);
     Q_INVOKABLE QString getGameLandscapeImageFromCache(const QString &serviceType, const QString &gameIdentifier);
 
@@ -112,6 +111,10 @@ private:
     } gameDetailsState;
 
     // Helper methods
+    // PSCloud entitlement → productId library lookup (used by getGameLandscapeImageFromCache
+    // and createCloudSteamShortcut). Returns productId from ps5_cloud_library cache, or
+    // entitlementId if not found.
+    QString findProductIdForEntitlement(const QString &entitlementId);
     void setCachedData(const QString &key, const QJsonDocument &data);
     QString getCachedPs5CatalogV3(int maxAge);
     QString getCacheFilePath(const QString &key);

--- a/gui/include/cloudcatalogbackend.h
+++ b/gui/include/cloudcatalogbackend.h
@@ -19,6 +19,8 @@
 #include <QFile>
 #include <QStandardPaths>
 
+#include <QHash>
+#include <QPointer>
 #include <atomic>
 #include <vector>
 
@@ -99,6 +101,9 @@ private:
     // the GUI/engine thread (Q_INVOKABLE entry + the queued completion handler).
     std::atomic<bool> unifiedFetchInFlight{false};
     std::vector<QJSValue> pendingUnifiedCallbacks;
+
+    QHash<quint64, QJSValue> pending_callbacks; // GUI thread only
+    quint64 next_request_id = 0;
 
     // Game details fetching state
     struct GameDetailsState {

--- a/gui/include/cloudstreamingbackend.h
+++ b/gui/include/cloudstreamingbackend.h
@@ -39,7 +39,6 @@ class CloudStreamingBackend : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString allocationProgress READ getAllocationProgress NOTIFY allocationProgressChanged)
-    Q_PROPERTY(int queuePosition READ getQueuePosition NOTIFY queuePositionChanged)
     Q_PROPERTY(QString gameImageUrl READ getGameImageUrl WRITE setGameImageUrl NOTIFY gameImageUrlChanged)
 
 public:
@@ -56,7 +55,6 @@ public:
     Q_INVOKABLE void startCompleteCloudSession(QString serviceType, QString gameIdentifier, const QJSValue &callback);
     
     QString getAllocationProgress() const { return allocation_progress; }
-    int getQueuePosition() const { return queue_position; }
     QString getGameImageUrl() const { return game_image_url; }
     void setGameImageUrl(const QString &url);
 
@@ -65,13 +63,11 @@ signals:
     void sessionCreated(StreamSession *session);
     // Emitted when allocation progress updates
     void allocationProgressChanged();
-    // Emitted when queue position changes
-    void queuePositionChanged();
     // Emitted when game image URL changes
     void gameImageUrlChanged();
 
 private slots:
-    void onAllocationProgress(QString message, int queuePosition = -1);
+    void onAllocationProgress(QString message);
 
 private:
     void setAllocationProgress(const QString &message);
@@ -94,7 +90,6 @@ private:
 
     Settings *settings;
     QString allocation_progress;
-    int queue_position = -1;  // -1 means not queued or no position available
     QString game_image_url;  // Landscape image URL for current cloud game
 
     QHash<quint64, QJSValue> pending_callbacks; // GUI thread only

--- a/gui/include/cloudstreamingbackend.h
+++ b/gui/include/cloudstreamingbackend.h
@@ -8,6 +8,8 @@
 #include <QObject>
 #include <QString>
 #include <QJSValue>
+#include <QHash>
+#include <QPointer>
 
 // ============================================================================
 // CONFIGURATION - Shared settings and values used by multiple classes
@@ -94,6 +96,9 @@ private:
     QString allocation_progress;
     int queue_position = -1;  // -1 means not queued or no position available
     QString game_image_url;  // Landscape image URL for current cloud game
+
+    QHash<quint64, QJSValue> pending_callbacks; // GUI thread only
+    quint64 next_request_id = 0;
 };
 
 #endif // CLOUDSTREAMINGBACKEND_H

--- a/gui/include/cloudstreamingbackend.h
+++ b/gui/include/cloudstreamingbackend.h
@@ -43,6 +43,9 @@ class CloudStreamingBackend : public QObject
 public:
     explicit CloudStreamingBackend(Settings *settings, QObject *parent = nullptr);
 
+    // Rebind to a new profile's Settings (profile switch deletes the old object).
+    void setSettings(Settings *new_settings) { settings = new_settings; }
+
     // MAIN ENTRY POINT - Complete cloud streaming session (Steps 1-13)
     // Parameters:
     //   serviceType: "psnow" or "pscloud"

--- a/gui/include/streamsession.h
+++ b/gui/include/streamsession.h
@@ -351,11 +351,11 @@ class StreamSession : public QObject
 			// than requested. Fall back to the requested profile before the first
 			// frame selects an adaptive profile.
 			int w = 0, h = 0;
-			ChiakiVideoReceiver *vr = session.stream_connection.video_receiver;
-			if(vr && vr->profile_cur >= 0 && (size_t)vr->profile_cur < vr->profiles_count)
+			unsigned int uw = 0, uh = 0;
+			if(chiaki_stream_connection_video_resolution(&session.stream_connection, &uw, &uh))
 			{
-				w = (int)vr->profiles[vr->profile_cur].width;
-				h = (int)vr->profiles[vr->profile_cur].height;
+				w = (int)uw;
+				h = (int)uh;
 			}
 			else
 			{

--- a/gui/src/cloudcatalogbackend.cpp
+++ b/gui/src/cloudcatalogbackend.cpp
@@ -490,7 +490,7 @@ QString CloudCatalogBackend::getGameLandscapeImageFromCache(const QString &servi
     QString productIdForCatalog; // For PSCloud: productId to use in catalog lookup
     
     if (serviceType.toLower() == "psnow") {
-        cacheKey = "psnow_catalog";
+        cacheKey = "unified_catalog_v3";
     } else if (serviceType.toLower() == "pscloud") {
         // For PSCloud, check game details cache first (has landscape images from API)
         // If gameIdentifier is an entitlement ID, we need to find the productId from library first
@@ -603,8 +603,10 @@ QString CloudCatalogBackend::getGameLandscapeImageFromCache(const QString &servi
         
         // Match based on service type
         if (serviceType.toLower() == "psnow") {
-            // PSNOW: Match by "id" field (product ID)
-            if (game.contains("id") && game["id"].toString() == gameIdentifier) {
+            // PSNOW: unified catalog rows may carry the identifier under several keys.
+            if ((game.contains("id") && game["id"].toString() == gameIdentifier)
+                || (game.contains("storeProductId") && game["storeProductId"].toString() == gameIdentifier)
+                || (game.contains("productId") && game["productId"].toString() == gameIdentifier)) {
                 gameObj = game;
                 found = true;
                 break;

--- a/gui/src/cloudcatalogbackend.cpp
+++ b/gui/src/cloudcatalogbackend.cpp
@@ -22,6 +22,7 @@
 #include <QEventLoop>
 #include <QTimer>
 #include <QCoreApplication>
+#include <QPointer>
 #include <QProcessEnvironment>
 #include <QImageReader>
 #include <QPainter>
@@ -224,12 +225,16 @@ void CloudCatalogBackend::fetchUnifiedCatalog(const QJSValue &callback)
         return;
     }
 
+    const quint64 reqId = ++next_request_id;
+    pending_callbacks.insert(reqId, cb);
+    QPointer<CloudCatalogBackend> self(this);
+
     const QByteArray npsso = getNpSsoToken().toUtf8();
     const QByteArray locale =
         (settings ? settings->GetCloudStoreLocale() : QStringLiteral("en-US")).toUtf8();
     const QByteArray cacheDir = cacheDirectory.toUtf8();
 
-    std::thread([this, cb, npsso, locale, cacheDir]() mutable {
+    std::thread([self, reqId, npsso, locale, cacheDir]() mutable {
         ChiakiLog log;
         chiaki_log_init(&log, CHIAKI_LOG_INFO | CHIAKI_LOG_WARNING | CHIAKI_LOG_ERROR,
                         chiaki_log_cb_print, nullptr);
@@ -250,14 +255,16 @@ void CloudCatalogBackend::fetchUnifiedCatalog(const QJSValue &callback)
             : QString::fromUtf8(res.error_message ? res.error_message : "Failed to fetch cloud catalog");
         chiaki_cloudcatalog_result_fini(&res);
 
-        // QJSValue must be invoked on the engine (main) thread; the queued call is
-        // discarded automatically if `this` is destroyed first. The in-flight flag is
-        // cleared here (on the GUI thread) AFTER draining any callbacks that were
-        // coalesced while this fetch ran, so they all receive the same result.
-        QMetaObject::invokeMethod(this, [this, cb, success, message, json]() mutable {
+        // QJSValue must be invoked on the engine (main) thread. Route through qApp so
+        // the callback is fetched and invoked on the GUI thread even if `self` is
+        // destroyed before the worker finishes.
+        QMetaObject::invokeMethod(qApp, [self, reqId, success, message, json]() mutable {
+            if (!self)
+                return; // backend destroyed while the worker ran
+            const QJSValue cb = self->pending_callbacks.take(reqId);
             std::vector<QJSValue> parked;
-            parked.swap(pendingUnifiedCallbacks);
-            unifiedFetchInFlight.store(false);
+            parked.swap(self->pendingUnifiedCallbacks);
+            self->unifiedFetchInFlight.store(false);
 
             // Persist the locale the lib actually settled on (region detection now lives
             // entirely in libchiaki: it re-bases the locale on the account's Kamaji-session
@@ -265,14 +272,14 @@ void CloudCatalogBackend::fetchUnifiedCatalog(const QJSValue &callback)
             // Mirrors iOS noteSettledLocale / Android noteCloudStoreLocaleSettled. Uses the core
             // Settings setter (NOT QmlSettings), so it does NOT invalidate the cache the lib
             // just wrote; otherwise an international account would thrash the catalog.
-            if (success && settings) {
+            if (success && self->settings) {
                 const QJsonObject root = QJsonDocument::fromJson(json.toUtf8()).object();
                 const QString settled = root.value(QStringLiteral("settledLocale")).toString();
-                if (!settled.isEmpty() && settled != settings->GetCloudStoreLocale())
-                    settings->SetCloudStoreLocale(settled);
-                settings->SetCloudResolvedStoreCountry(root.value(QStringLiteral("fallbackRegion")).toString());
-                settings->SetCloudResolvedStoreLang(root.value(QStringLiteral("resolvedStoreLang")).toString());
-                settings->SetCloudCatalogNativeMode(root.value(QStringLiteral("nativeMode")).toBool(true));
+                if (!settled.isEmpty() && settled != self->settings->GetCloudStoreLocale())
+                    self->settings->SetCloudStoreLocale(settled);
+                self->settings->SetCloudResolvedStoreCountry(root.value(QStringLiteral("fallbackRegion")).toString());
+                self->settings->SetCloudResolvedStoreLang(root.value(QStringLiteral("resolvedStoreLang")).toString());
+                self->settings->SetCloudCatalogNativeMode(root.value(QStringLiteral("nativeMode")).toBool(true));
             }
 
             const QJSValue payload = success ? QJSValue(json) : QJSValue();

--- a/gui/src/cloudcatalogbackend.cpp
+++ b/gui/src/cloudcatalogbackend.cpp
@@ -479,6 +479,37 @@ QJsonObject CloudCatalogBackend::extractGameImages(const QJsonObject &gameData)
     return images;
 }
 
+QString CloudCatalogBackend::findProductIdForEntitlement(const QString &entitlementId)
+{
+    QString libraryCached = getCachedData("ps5_cloud_library", INT_MAX);
+    if (libraryCached.isEmpty())
+        return entitlementId;
+    QJsonDocument libraryDoc = QJsonDocument::fromJson(libraryCached.toUtf8());
+    if (!libraryDoc.isObject())
+        return entitlementId;
+    QJsonObject libraryRoot = libraryDoc.object();
+    if (!libraryRoot.contains("games") || !libraryRoot["games"].isArray())
+        return entitlementId;
+    QJsonArray libraryGames = libraryRoot["games"].toArray();
+    for (const QJsonValue &gameValue : libraryGames) {
+        if (!gameValue.isObject()) continue;
+        QJsonObject game = gameValue.toObject();
+        if (!game.contains("id") || game["id"].toString() != entitlementId) continue;
+        if (game.contains("product_id")) {
+            QString productId = game["product_id"].toString();
+            if (!productId.isEmpty())
+                return productId;
+        }
+        // Fallback: id itself (same as input — return it explicitly so callers can detect no-op)
+        if (game.contains("id")) {
+            QString id = game["id"].toString();
+            if (!id.isEmpty())
+                return id;
+        }
+    }
+    return entitlementId;
+}
+
 QString CloudCatalogBackend::getGameLandscapeImageFromCache(const QString &serviceType, const QString &gameIdentifier)
 {
     if (gameIdentifier.isEmpty()) {
@@ -492,45 +523,10 @@ QString CloudCatalogBackend::getGameLandscapeImageFromCache(const QString &servi
     if (serviceType.toLower() == "psnow") {
         cacheKey = "unified_catalog_v3";
     } else if (serviceType.toLower() == "pscloud") {
-        // For PSCloud, check game details cache first (has landscape images from API)
-        // If gameIdentifier is an entitlement ID, we need to find the productId from library first
-        // Use very large maxAge to never invalidate cache (read-only operation)
-        QString libraryCached = getCachedData("ps5_cloud_library", INT_MAX);
-        if (!libraryCached.isEmpty()) {
-            QJsonDocument libraryDoc = QJsonDocument::fromJson(libraryCached.toUtf8());
-            if (libraryDoc.isObject()) {
-                QJsonObject libraryRoot = libraryDoc.object();
-                if (libraryRoot.contains("games") && libraryRoot["games"].isArray()) {
-                    QJsonArray libraryGames = libraryRoot["games"].toArray();
-                    for (const QJsonValue &gameValue : libraryGames) {
-                        if (!gameValue.isObject()) continue;
-                        QJsonObject game = gameValue.toObject();
-                        // Match by entitlement ID (id field)
-                        if (game.contains("id") && game["id"].toString() == gameIdentifier) {
-                            // Found in library, get productId - prioritize product_id, fallback to id
-                            if (game.contains("product_id")) {
-                                QString productId = game["product_id"].toString();
-                                if (!productId.isEmpty()) {
-                                    productIdForCatalog = productId;
-                                    qInfo() << "getGameLandscapeImage: Found productId" << productIdForCatalog << "for entitlement ID" << gameIdentifier;
-                                    break;
-                                }
-                            }
-                            // Fallback to id if product_id is missing or empty
-                            if (productIdForCatalog.isEmpty() && game.contains("id")) {
-                                QString id = game["id"].toString();
-                                if (!id.isEmpty()) {
-                                    productIdForCatalog = id;
-                                    qInfo() << "getGameLandscapeImage: Using id as productId fallback" << productIdForCatalog << "for entitlement ID" << gameIdentifier;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        
+        // For PSCloud, gameIdentifier is an entitlement ID; resolve productId from library.
+        productIdForCatalog = findProductIdForEntitlement(gameIdentifier);
+        qInfo() << "getGameLandscapeImage: resolved productId" << productIdForCatalog << "for entitlement ID" << gameIdentifier;
+
         // Try game details cache first (has landscape images from API)
         // Use very large maxAge to never invalidate cache (read-only operation)
         QString lookupId = productIdForCatalog.isEmpty() ? gameIdentifier : productIdForCatalog;
@@ -699,19 +695,6 @@ QString CloudCatalogBackend::getGameLandscapeImageFromCache(const QString &servi
     return QString();
 }
 
-void CloudCatalogBackend::invalidatePs5CatalogCache()
-{
-    for (const QString &key :
-         {QStringLiteral("ps5_cloud_catalog_v6"), QStringLiteral("ps5_cloud_catalog_v5"), QStringLiteral("ps5_cloud_catalog_v4"), QStringLiteral("ps5_cloud_catalog_v3"),
-          QStringLiteral("ps5_cloud_catalog_v2"), QStringLiteral("ps5_cloud_catalog")}) {
-        const QString path = getCacheFilePath(key);
-        if (QFile::exists(path)) {
-            QFile::remove(path);
-            qInfo() << "[CACHE INVALIDATED] Removed PS5 cloud catalog cache:" << key;
-        }
-    }
-}
-
 void CloudCatalogBackend::invalidateCache()
 {
     // libchiaki owns every cache file and its versioned key (current + legacy), so
@@ -872,47 +855,13 @@ void CloudCatalogBackend::createCloudSteamShortcut(const QString &gameIdentifier
         return;
     }
     
-    // For PSCloud (cloudGameLibrary), gameIdentifier is entitlement ID, need to look up product_id
-    // For PSNOW (cloudGameCatalog), gameIdentifier is already the product ID
-    QString productIdForCache = gameIdentifier;
-    if (command == "cloudGameLibrary") {
-        // Look up product_id from library using entitlement ID
-        QString libraryCached = getCachedData("ps5_cloud_library", INT_MAX);
-        if (!libraryCached.isEmpty()) {
-            QJsonDocument libraryDoc = QJsonDocument::fromJson(libraryCached.toUtf8());
-            if (libraryDoc.isObject()) {
-                QJsonObject libraryRoot = libraryDoc.object();
-                if (libraryRoot.contains("games") && libraryRoot["games"].isArray()) {
-                    QJsonArray libraryGames = libraryRoot["games"].toArray();
-                    for (const QJsonValue &gameValue : libraryGames) {
-                        if (!gameValue.isObject()) continue;
-                        QJsonObject game = gameValue.toObject();
-                        // Match by entitlement ID (id field)
-                        if (game.contains("id") && game["id"].toString() == gameIdentifier) {
-                            // Found in library, get productId - prioritize product_id, fallback to id
-                            if (game.contains("product_id")) {
-                                QString productId = game["product_id"].toString();
-                                if (!productId.isEmpty()) {
-                                    productIdForCache = productId;
-                                    qInfo() << "createCloudSteamShortcut: Found productId" << productIdForCache << "for entitlement ID" << gameIdentifier;
-                                    break;
-                                }
-                            }
-                            // Fallback to id if product_id is missing or empty
-                            if (productIdForCache == gameIdentifier && game.contains("id")) {
-                                QString id = game["id"].toString();
-                                if (!id.isEmpty()) {
-                                    productIdForCache = id;
-                                    qInfo() << "createCloudSteamShortcut: Using id as productId fallback" << productIdForCache << "for entitlement ID" << gameIdentifier;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+    // For PSCloud (cloudGameLibrary), gameIdentifier is entitlement ID, need to look up product_id.
+    // For PSNOW (cloudGameCatalog), gameIdentifier is already the product ID.
+    QString productIdForCache = (command == "cloudGameLibrary")
+        ? findProductIdForEntitlement(gameIdentifier)
+        : gameIdentifier;
+    if (command == "cloudGameLibrary")
+        qInfo() << "createCloudSteamShortcut: resolved productId" << productIdForCache << "for entitlement ID" << gameIdentifier;
     
     // Get cached game details using product ID
     QString cacheKey = QString("game_details_%1").arg(productIdForCache);

--- a/gui/src/cloudstreamingbackend.cpp
+++ b/gui/src/cloudstreamingbackend.cpp
@@ -341,11 +341,6 @@ void CloudStreamingBackend::finishCloudSession(QString serviceType, QString serv
         emit sessionCreated(session);
 
         setAllocationProgress("");
-        if (queue_position != -1) {
-            queue_position = -1;
-            emit queuePositionChanged();
-        }
-
         session->Start();
         qInfo() << "StreamSession Start() called (connection is asynchronous)";
 
@@ -425,10 +420,6 @@ void CloudStreamingBackend::handleProvisionError(QString serviceType, QString er
     }
 
     setAllocationProgress("");
-    if (queue_position != -1) {
-        queue_position = -1;
-        emit queuePositionChanged();
-    }
 }
 
 // C progress callback -- runs on the worker thread; marshal to the GUI thread.
@@ -445,13 +436,9 @@ void CloudStreamingBackend::provisionProgressThunk(const char *stage, void *user
     }, Qt::QueuedConnection);
 }
 
-void CloudStreamingBackend::onAllocationProgress(QString message, int queuePosition)
+void CloudStreamingBackend::onAllocationProgress(QString message)
 {
     setAllocationProgress(message);
-    if (queue_position != queuePosition) {
-        queue_position = queuePosition;
-        emit queuePositionChanged();
-    }
 }
 
 

--- a/gui/src/cloudstreamingbackend.cpp
+++ b/gui/src/cloudstreamingbackend.cpp
@@ -11,8 +11,10 @@
 #include "cloudcatalogbackend.h"
 
 #include <QObject>
+#include <QCoreApplication>
 #include <QDateTime>
 #include <QLoggingCategory>
+#include <QPointer>
 #include <QSet>
 #include <QJsonObject>
 #include <QJsonDocument>
@@ -154,7 +156,11 @@ void CloudStreamingBackend::continueCloudSessionAfterAuth(QString serviceType, Q
 
     setAllocationProgress(tr("Starting cloud session..."));
 
-    std::thread([this, callback, svc, gameId, npsso, storeCountry, storeLang, gameLang,
+    const quint64 reqId = ++next_request_id;
+    pending_callbacks.insert(reqId, callback);
+    QPointer<CloudStreamingBackend> self(this);
+
+    std::thread([self, reqId, svc, gameId, npsso, storeCountry, storeLang, gameLang,
                  forcedDc, priorDc, resolution, bitrate, isForeign, attrPassed, ownedEnt, ownedPlat]() mutable {
         ChiakiLog log;
         chiaki_log_init(&log, CHIAKI_LOG_INFO | CHIAKI_LOG_WARNING | CHIAKI_LOG_ERROR,
@@ -178,7 +184,7 @@ void CloudStreamingBackend::continueCloudSessionAfterAuth(QString serviceType, Q
         cfg.bitrate_kbps = bitrate;
         cfg.progress = &CloudStreamingBackend::provisionProgressThunk;
         cfg.is_cancelled = nullptr;
-        cfg.user = this;
+        cfg.user = &self; // address of the lambda-local QPointer — valid for the blocking call's lifetime
 
         ChiakiCloudProvisionResult res;
         ChiakiErrorCode err = chiaki_cloud_provision_session(&cfg, &res, &log);
@@ -197,21 +203,24 @@ void CloudStreamingBackend::continueCloudSessionAfterAuth(QString serviceType, Q
         const QString dcPings = res.datacenter_pings ? QString::fromUtf8(res.datacenter_pings) : QString();
         chiaki_cloud_provision_result_fini(&res);
 
-        QMetaObject::invokeMethod(this, [this, callback, success, serviceTypeStr, serverIp, serverPort,
+        QMetaObject::invokeMethod(qApp, [self, reqId, success, serviceTypeStr, serverIp, serverPort,
                                          handshakeKey, launchSpec, sessionId, wrap, mtuIn, mtuOut, rttUs, errMsg, dcPings]() mutable {
+            if (!self)
+                return; // backend destroyed while the worker ran
+            const QJSValue callback = self->pending_callbacks.take(reqId);
             // Persist the merged datacenter list so Settings shows the measured RTTs
             // (done whether or not allocation succeeded -- the old code saved during the ping).
             if (!dcPings.isEmpty()) {
-                if (serviceTypeStr == "pscloud") settings->SetCloudDatacentersJsonPSCloud(dcPings);
-                else settings->SetCloudDatacentersJsonPSNOW(dcPings);
+                if (serviceTypeStr == "pscloud") self->settings->SetCloudDatacentersJsonPSCloud(dcPings);
+                else self->settings->SetCloudDatacentersJsonPSNOW(dcPings);
             }
             if (success) {
-                finishCloudSession(serviceTypeStr, serverIp, serverPort, handshakeKey, launchSpec,
-                                   sessionId, wrap, mtuIn, mtuOut, rttUs, callback);
+                self->finishCloudSession(serviceTypeStr, serverIp, serverPort, handshakeKey, launchSpec,
+                                         sessionId, wrap, mtuIn, mtuOut, rttUs, callback);
             } else {
-                handleProvisionError(serviceTypeStr, errMsg, callback);
+                self->handleProvisionError(serviceTypeStr, errMsg, callback);
             }
-        });
+        }, Qt::QueuedConnection);
     }).detach();
 }
 
@@ -423,11 +432,15 @@ void CloudStreamingBackend::handleProvisionError(QString serviceType, QString er
 // C progress callback -- runs on the worker thread; marshal to the GUI thread.
 void CloudStreamingBackend::provisionProgressThunk(const char *stage, void *user)
 {
-    auto *self = static_cast<CloudStreamingBackend*>(user);
-    if (!self || !stage)
+    auto *holder = static_cast<QPointer<CloudStreamingBackend>*>(user);
+    if (!holder || !stage)
         return;
+    QPointer<CloudStreamingBackend> self = *holder; // QPointer copy is thread-safe
     const QString s = QString::fromUtf8(stage);
-    QMetaObject::invokeMethod(self, [self, s]() { self->setAllocationProgress(s); });
+    QMetaObject::invokeMethod(qApp, [self, s]() {
+        if (self)
+            self->setAllocationProgress(s);
+    }, Qt::QueuedConnection);
 }
 
 void CloudStreamingBackend::onAllocationProgress(QString message, int queuePosition)

--- a/gui/src/cloudstreamingbackend.cpp
+++ b/gui/src/cloudstreamingbackend.cpp
@@ -203,7 +203,7 @@ void CloudStreamingBackend::continueCloudSessionAfterAuth(QString serviceType, Q
         const QString dcPings = res.datacenter_pings ? QString::fromUtf8(res.datacenter_pings) : QString();
         chiaki_cloud_provision_result_fini(&res);
 
-        QMetaObject::invokeMethod(qApp, [self, reqId, success, serviceTypeStr, serverIp, serverPort,
+        QMetaObject::invokeMethod(qApp, [self, reqId, success, attrPassed, serviceTypeStr, serverIp, serverPort,
                                          handshakeKey, launchSpec, sessionId, wrap, mtuIn, mtuOut, rttUs, errMsg, dcPings]() mutable {
             if (!self)
                 return; // backend destroyed while the worker ran
@@ -215,6 +215,8 @@ void CloudStreamingBackend::continueCloudSessionAfterAuth(QString serviceType, Q
                 else self->settings->SetCloudDatacentersJsonPSNOW(dcPings);
             }
             if (success) {
+                if (!attrPassed)
+                    self->settings->SetAccountAttributesCheckPassed(true);
                 self->finishCloudSession(serviceTypeStr, serverIp, serverPort, handshakeKey, launchSpec,
                                          sessionId, wrap, mtuIn, mtuOut, rttUs, callback);
             } else {

--- a/gui/src/cloudstreamingbackend.cpp
+++ b/gui/src/cloudstreamingbackend.cpp
@@ -428,7 +428,12 @@ void CloudStreamingBackend::provisionProgressThunk(const char *stage, void *user
     auto *holder = static_cast<QPointer<CloudStreamingBackend>*>(user);
     if (!holder || !stage)
         return;
-    QPointer<CloudStreamingBackend> self = *holder; // QPointer copy is thread-safe
+    // NOTE: copying a QPointer off the GUI thread is not strictly thread-safe (it touches the
+    // QWeakPointer control block, which the GUI thread mutates on destruction). It is safe HERE
+    // only because CloudStreamingBackend is owned by QmlBackend and outlives every provision, so
+    // it is never destroyed concurrently with a progress callback. Do not copy this pattern to a
+    // backend with a shorter lifetime.
+    QPointer<CloudStreamingBackend> self = *holder;
     const QString s = QString::fromUtf8(stage);
     QMetaObject::invokeMethod(qApp, [self, s]() {
         if (self)

--- a/gui/src/qmlbackend.cpp
+++ b/gui/src/qmlbackend.cpp
@@ -737,6 +737,8 @@ void QmlBackend::profileChanged()
         cloud_catalog_backend->setSettings(settings);
         cloud_catalog_backend->invalidateCache();
     }
+    if(cloud_streaming_backend)
+        cloud_streaming_backend->setSettings(settings);
 
     auto_connect_mac = settings->GetAutoConnectHost().GetServerMAC();
     auto_connect_nickname = settings->GetAutoConnectHost().GetServerNickname();

--- a/ios/Pylux/Bridge/CloudCatalogBridge.h
+++ b/ios/Pylux/Bridge/CloudCatalogBridge.h
@@ -26,9 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
                                     forceRefresh:(BOOL)forceRefresh
                                     errorMessage:(NSString * _Nullable * _Nullable)errorMessage;
 
-/// Bare lowercase language code Gaikai expects ("de-DE" -> "de"); "en" default.
-+ (NSString *)gaikaiLanguageForLocale:(nullable NSString *)locale;
-
 /// Locales offered in the language picker (BCP-47, e.g. "en-GB").
 + (NSArray<NSString *> *)supportedCloudLanguages;
 

--- a/ios/Pylux/Bridge/CloudCatalogBridge.m
+++ b/ios/Pylux/Bridge/CloudCatalogBridge.m
@@ -55,12 +55,6 @@ static void cc_log_cb(ChiakiLogLevel level, const char *msg, void *user) {
     return json;
 }
 
-+ (NSString *)gaikaiLanguageForLocale:(NSString *)locale {
-    char buf[16];
-    chiaki_cloud_gaikai_language(locale.length > 0 ? locale.UTF8String : NULL, buf, sizeof(buf));
-    return [NSString stringWithUTF8String:buf];
-}
-
 + (NSArray<NSString *> *)supportedCloudLanguages {
     NSMutableArray<NSString *> *out = [NSMutableArray array];
     size_t n = chiaki_cloud_supported_locale_count();

--- a/ios/Pylux/Views/CloudPlayView.swift
+++ b/ios/Pylux/Views/CloudPlayView.swift
@@ -36,7 +36,6 @@ final class CloudPlayViewModel: ObservableObject {
     @Published var refreshing = false
     @Published var error: String?
     @Published var warning: String?
-    @Published var fallbackRegion: String = SecureStore.shared.cloudResolvedStoreCountry
     @Published var catalogIsForeign: Bool = SecureStore.shared.isCloudCatalogIsForeign
     @Published var searchQuery = ""
     @Published var sortOrder: SortOrder = .defaultOrder
@@ -154,7 +153,6 @@ final class CloudPlayViewModel: ObservableObject {
     private func applyLoadedGames(_ loadedGames: [CloudGame]) {
         games = loadedGames
         loading = false
-        fallbackRegion = SecureStore.shared.cloudResolvedStoreCountry
         catalogIsForeign = SecureStore.shared.isCloudCatalogIsForeign
         if let fetchError = catalogService.lastLibraryFetchError {
             error = fetchError

--- a/lib/include/chiaki/streamconnection.h
+++ b/lib/include/chiaki/streamconnection.h
@@ -109,6 +109,14 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_stream_connection_stop(ChiakiStreamConnecti
 
 CHIAKI_EXPORT ChiakiErrorCode stream_connection_send_corrupt_frame(ChiakiStreamConnection *stream_connection, ChiakiSeqNum16 start, ChiakiSeqNum16 end);
 
+/**
+ * Thread-safe read of the currently-decoded video resolution (the negotiated/adaptive
+ * profile). Returns false if no profile is active yet (caller should fall back to the
+ * requested connect_info profile).
+ */
+CHIAKI_EXPORT bool chiaki_stream_connection_video_resolution(ChiakiStreamConnection *stream_connection,
+		unsigned int *width, unsigned int *height);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/include/chiaki/streamconnection.h
+++ b/lib/include/chiaki/streamconnection.h
@@ -117,6 +117,12 @@ CHIAKI_EXPORT ChiakiErrorCode stream_connection_send_corrupt_frame(ChiakiStreamC
 CHIAKI_EXPORT bool chiaki_stream_connection_video_resolution(ChiakiStreamConnection *stream_connection,
 		unsigned int *width, unsigned int *height);
 
+/**
+ * Thread-safe read of the cumulative dropped-frames counter for the stats overlay.
+ * Returns 0 if no video receiver is active (yet or anymore).
+ */
+CHIAKI_EXPORT uint64_t chiaki_stream_connection_video_frames_lost(ChiakiStreamConnection *stream_connection);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/include/chiaki/thread.h
+++ b/lib/include/chiaki/thread.h
@@ -35,6 +35,7 @@ typedef struct chiaki_thread_t
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_create(ChiakiThread *thread, ChiakiThreadFunc func, void *arg);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_join(ChiakiThread *thread, void **retval);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_timedjoin(ChiakiThread *thread, void **retval, uint64_t timeout_ms);
+CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_detach(ChiakiThread *thread);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_set_name(ChiakiThread *thread, const char *name);
 
 

--- a/lib/src/cloudcatalog_cache.c
+++ b/lib/src/cloudcatalog_cache.c
@@ -84,11 +84,11 @@ struct json_object *cc_cache_read(ChiakiLog *log, const char *cache_dir, const c
 	}
 
 	time_t now = time(NULL);
-	long age_ms = (long)(now - st.st_mtime) * 1000L;
+	int64_t age_ms = (int64_t)difftime(now, st.st_mtime) * 1000;
 	if(age_ms > max_age_ms)
 	{
 		remove(path);
-		CHIAKI_LOGI(log, "[CACHE EXPIRED] %s (age %lds)", key, age_ms / 1000);
+		CHIAKI_LOGI(log, "[CACHE EXPIRED] %s (age %lldsec)", key, (long long)(age_ms / 1000));
 		return NULL;
 	}
 
@@ -121,7 +121,7 @@ struct json_object *cc_cache_read(ChiakiLog *log, const char *cache_dir, const c
 		remove(path);
 		return NULL;
 	}
-	CHIAKI_LOGI(log, "[CACHE HIT] %s (%ldKB, age %lds)", key, sz / 1024, age_ms / 1000);
+	CHIAKI_LOGI(log, "[CACHE HIT] %s (%ldKB, age %lldsec)", key, sz / 1024, (long long)(age_ms / 1000));
 	return obj;
 }
 

--- a/lib/src/cloudcatalog_fetch.c
+++ b/lib/src/cloudcatalog_fetch.c
@@ -357,7 +357,8 @@ static bool psnow_root_categories(ChiakiLog *log, const char *base_url, const ch
 }
 
 // GET one category page (?start=0&size=500), append product rows to all_games.
-static void psnow_fetch_category(ChiakiLog *log, const char *cat_url, struct json_object *all_games)
+// Returns true on success (HTTP 200 + parseable body), false on HTTP/parse failure.
+static bool psnow_fetch_category(ChiakiLog *log, const char *cat_url, struct json_object *all_games)
 {
 	char url[1200];
 	snprintf(url, sizeof(url), strchr(cat_url, '?') ? "%s&start=0&size=500" : "%s?start=0&size=500", cat_url);
@@ -374,12 +375,12 @@ static void psnow_fetch_category(ChiakiLog *log, const char *cat_url, struct jso
 	if(cc_http_perform(log, &req, &resp) != CHIAKI_ERR_SUCCESS || resp.status_code != 200)
 	{
 		cc_http_response_fini(&resp);
-		return;
+		return false;
 	}
 	struct json_object *obj = parse_body(&resp);
 	cc_http_response_fini(&resp);
 	if(!obj)
-		return;
+		return false;
 	struct json_object *links = cc_json_arr(obj, "links");
 	if(links)
 	{
@@ -398,11 +399,13 @@ static void psnow_fetch_category(ChiakiLog *log, const char *cat_url, struct jso
 		}
 	}
 	json_object_put(obj);
+	return true;
 }
 
 CCNativeResult cc_fetch_psnow_native(ChiakiLog *log, const char *npsso, struct json_object **out_games,
 	char *out_country, size_t cc_sz, char *out_language, size_t lang_sz,
-	char *out_store_country, size_t store_cc_sz, char *out_store_lang, size_t store_lang_sz)
+	char *out_store_country, size_t store_cc_sz, char *out_store_lang, size_t store_lang_sz,
+	bool *out_complete)
 {
 	*out_games = NULL;
 	if(out_country && cc_sz)
@@ -446,8 +449,22 @@ CCNativeResult cc_fetch_psnow_native(ChiakiLog *log, const char *npsso, struct j
 		return CC_NATIVE_REGION_UNSUPPORTED;
 
 	struct json_object *all = json_object_new_array();
+	bool complete = true;
+	if(out_complete) *out_complete = true;
 	for(int i = 0; i < cat_count; i++)
-		psnow_fetch_category(log, cat_urls[i], all);
+	{
+		if(i) CC_MS_SLEEP(100);
+		if(!psnow_fetch_category(log, cat_urls[i], all))
+		{
+			CC_MS_SLEEP(500);
+			if(!psnow_fetch_category(log, cat_urls[i], all))
+			{
+				complete = false;
+				if(out_complete) *out_complete = false;
+				CHIAKI_LOGW(log, "[PSNOW] category %d failed; catalog incomplete", i);
+			}
+		}
+	}
 
 	// Dedup by id (first-wins).
 	struct json_object *seen = json_object_new_object();
@@ -818,6 +835,7 @@ CCOwnedResult cc_fetch_owned(ChiakiLog *log, const char *npsso,
 		if(page_count < OWNED_PAGE_SIZE)
 			break;
 		start += page_count;
+		CC_MS_SLEEP(100);
 	}
 	free(bearer);
 

--- a/lib/src/cloudcatalog_internal.h
+++ b/lib/src/cloudcatalog_internal.h
@@ -162,6 +162,10 @@ void cc_merge_imagic_list(const char *category_list, struct json_object *list_do
 /** Cover-image extraction (images[type 10]>12>13, then imageUrl). Returns "" if none. */
 const char *cc_extract_cover_image(struct json_object *game_obj, char *out, size_t out_sz);
 
+/** Stable-key derivation for ownership-match: splits product_id on [-_], drops the last
+ *  token, joins with '|'. Returns "" if fewer than 2 tokens. */
+const char *cc_stable_key(const char *product_id, char *out, size_t out_sz);
+
 /**
  * Strip Sony's numeric serviceType and set canonical pscloud/psnow from
  * entitlement_attributes[].platform_id. Mirrors sanitizeOwnedEntitlementServiceType.

--- a/lib/src/cloudcatalog_internal.h
+++ b/lib/src/cloudcatalog_internal.h
@@ -21,6 +21,17 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#define CC_MS_SLEEP(ms) Sleep(ms)
+#else
+#include <unistd.h>
+#define CC_MS_SLEEP(ms) usleep((ms) * 1000)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -203,7 +214,8 @@ bool cc_parse_container_store_locale(const char *base_url,
  */
 CCNativeResult cc_fetch_psnow_native(ChiakiLog *log, const char *npsso, struct json_object **out_games,
 	char *out_country, size_t cc_sz, char *out_language, size_t lang_sz,
-	char *out_store_country, size_t store_cc_sz, char *out_store_lang, size_t store_lang_sz);
+	char *out_store_country, size_t store_cc_sz, char *out_store_lang, size_t store_lang_sz,
+	bool *out_complete);
 
 /** Public APOLLOROOT fallback pagination for @p account_country. New array or NULL. */
 struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account_country);

--- a/lib/src/cloudcatalog_merge.c
+++ b/lib/src/cloudcatalog_merge.c
@@ -204,7 +204,7 @@ static bool is_plus_catalog_list(const char *list)
 
 // productId stable key: drop last token of the dash/underscore split, join with '|'.
 // Writes into out (>=128). Returns out (empty if <2 tokens).
-static const char *stable_key(const char *product_id, char *out, size_t out_sz)
+const char *cc_stable_key(const char *product_id, char *out, size_t out_sz)
 {
 	out[0] = 0;
 	if(!product_id || !*product_id)
@@ -213,13 +213,8 @@ static const char *stable_key(const char *product_id, char *out, size_t out_sz)
 	int ntok = 0;
 	char buf[256];
 	snprintf(buf, sizeof(buf), "%s", product_id);
-	for(char *dash = strtok(buf, "-"); dash && ntok < 16; dash = strtok(NULL, "-"))
-	{
-		char sub[128];
-		snprintf(sub, sizeof(sub), "%s", dash);
-		for(char *us = strtok(sub, "_"); us && ntok < 16; us = strtok(NULL, "_"))
-			snprintf(tokens[ntok++], 64, "%s", us);
-	}
+	for(char *tok = strtok(buf, "-_"); tok && ntok < 16; tok = strtok(NULL, "-_"))
+		snprintf(tokens[ntok++], 64, "%s", tok);
 	if(ntok < 2)
 		return out;
 	ntok--; // drop last token
@@ -543,7 +538,7 @@ static void streamability_add_product(StreamabilityIndex *ix, const char *pid)
 		return;
 	set_add(ix->product_keys, pid);
 	char sk[128];
-	stable_key(pid, sk, sizeof(sk));
+	cc_stable_key(pid, sk, sizeof(sk));
 	if(*sk)
 		set_add(ix->product_keys, sk);
 }
@@ -584,7 +579,7 @@ static StreamabilityIndex streamability_build(struct json_object *apollo,
 				continue;
 			const char *pid = game_product_id(row);
 			char sk[128];
-			stable_key(pid, sk, sizeof(sk));
+			cc_stable_key(pid, sk, sizeof(sk));
 			if(set_has(ix.product_keys, pid) || (*sk && set_has(ix.product_keys, sk)))
 				set_add(ix.streamable_concepts, concept);
 		}
@@ -602,7 +597,7 @@ static bool streamability_is_streamable(StreamabilityIndex *ix, struct json_obje
 		if(set_has(ix->product_keys, ids[i]))
 			return true;
 		char sk[128];
-		stable_key(ids[i], sk, sizeof(sk));
+		cc_stable_key(ids[i], sk, sizeof(sk));
 		if(*sk && set_has(ix->product_keys, sk))
 			return true;
 	}
@@ -849,7 +844,7 @@ static void build_stable_index(struct json_object *arr, struct json_object *map)
 	{
 		struct json_object *g = json_object_array_get_idx(arr, i);
 		char sk[128];
-		stable_key(game_product_id(g), sk, sizeof(sk));
+		cc_stable_key(game_product_id(g), sk, sizeof(sk));
 		if(*sk)
 			objmap_put_first(map, sk, g);
 	}
@@ -1074,8 +1069,8 @@ struct json_object *cc_build_owned_cross_ref(ChiakiLog *log,
 		bool skip_demo = cc_contains(ent_name_lc, "demo");
 
 		char stable_k[128], ent_stable_k[128], owned_concept[24];
-		stable_key(product_id, stable_k, sizeof(stable_k));
-		stable_key(entitlement_id, ent_stable_k, sizeof(ent_stable_k));
+		cc_stable_key(product_id, stable_k, sizeof(stable_k));
+		cc_stable_key(entitlement_id, ent_stable_k, sizeof(ent_stable_k));
 		owned_concept_id(ow, owned_concept, sizeof(owned_concept));
 
 		struct json_object *meta = NULL;
@@ -1118,7 +1113,7 @@ struct json_object *cc_build_owned_cross_ref(ChiakiLog *log,
 				else
 				{
 					char sk[128];
-					stable_key(sibling_id, sk, sizeof(sk));
+					cc_stable_key(sibling_id, sk, sizeof(sk));
 					if(*sk && !skip_demo)
 					{
 						if((sibling_meta = objmap_get(browse_stable, sk))) { }

--- a/lib/src/cloudcatalog_unified.c
+++ b/lib/src/cloudcatalog_unified.c
@@ -264,8 +264,11 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 		struct json_object *g = cc_json_arr(v6, "games");
 		struct json_object *s = cc_json_arr(v6, "plusLibrarySupplement");
 		struct json_object *a = cc_json_obj(v6, "productIdAliases");
-		browse = cc_json_clone(g ? g : json_object_new_array());
-		supplement = cc_json_clone(s ? s : json_object_new_array());
+		struct json_object *fb = NULL;
+		browse = cc_json_clone(g ? g : (fb = json_object_new_array()));
+		if(fb) { json_object_put(fb); fb = NULL; }
+		supplement = cc_json_clone(s ? s : (fb = json_object_new_array()));
+		if(fb) { json_object_put(fb); fb = NULL; }
 		aliases = a ? cc_json_clone(a) : json_object_new_object();
 		const char *cl = cc_json_str(v6, "locale");
 		if(*cl)
@@ -319,7 +322,9 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 		{
 			struct json_object *g = cc_json_arr(lib, "games");
 			struct json_object *c = cc_json_obj(lib, "componentIdsByProductId");
-			owned = cc_json_clone(g ? g : json_object_new_array());
+			struct json_object *fb2 = NULL;
+			owned = cc_json_clone(g ? g : (fb2 = json_object_new_array()));
+			if(fb2) json_object_put(fb2);
 			components = c ? cc_json_clone(c) : json_object_new_object();
 			json_object_put(lib);
 		}

--- a/lib/src/cloudcatalog_unified.c
+++ b/lib/src/cloudcatalog_unified.c
@@ -167,9 +167,11 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 	char acct_country[8] = "", acct_language[8] = "";
 	char store_country[8] = "", store_lang[8] = "";
 
+	bool apollo_complete = true;
 	CCNativeResult nr = cc_fetch_psnow_native(log, npsso, &apollo,
 		acct_country, sizeof(acct_country), acct_language, sizeof(acct_language),
-		store_country, sizeof(store_country), store_lang, sizeof(store_lang));
+		store_country, sizeof(store_country), store_lang, sizeof(store_lang),
+		&apollo_complete);
 	if(nr == CC_NATIVE_OK)
 	{
 		native = true;
@@ -360,7 +362,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 	// 7. cache write guard (non-empty + not auth error).
 	struct json_object *games = cc_json_arr(env, "games");
 	int total = games ? (int)json_object_array_length(games) : 0;
-	if(total > 0 && !auth_error)
+	if(total > 0 && !auth_error && apollo_complete)
 		cc_cache_write(log, cache_dir, "unified_catalog_v3", env);
 
 	ChiakiErrorCode e = finish_ok(out, env);

--- a/lib/src/cloudsession.c
+++ b/lib/src/cloudsession.c
@@ -150,6 +150,16 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloud_provision_session(
 		return out->err;
 	}
 
+	// NULL fields treated as "" (documented config contract) — normalise before first use.
+	ChiakiCloudProvisionConfig c = *cfg;
+	#define CC_NZ(f) do { if(!c.f) c.f = ""; } while(0)
+	CC_NZ(service_type); CC_NZ(game_identifier); CC_NZ(npsso);
+	CC_NZ(store_country); CC_NZ(store_lang); CC_NZ(game_language);
+	CC_NZ(owned_entitlement_id); CC_NZ(owned_platform);
+	CC_NZ(forced_datacenter); CC_NZ(prior_datacenters_json);
+	#undef CC_NZ
+	cfg = &c;
+
 	// One shared client device uid for the Kamaji + Gaikai OAuth exchanges.
 	char duid[64];
 	size_t duid_size = sizeof(duid);

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -621,6 +621,7 @@ typedef struct
 	char *name, *ip, *session_key, *service_type; // strdup'd — owned by the job
 	int port, bw;
 	int64_t rtt_us; uint32_t mtu_in, mtu_out; bool ok;
+	atomic_int done;    // 1 once results are written; portable poll target for the deadline wait
 	atomic_int handoff; // 0 = thread running; first of {owner,thread} to exchange→1 must NOT free, second frees
 } GkPingJob;
 
@@ -638,6 +639,7 @@ static void *gk_ping_thread(void *arg)
 	cc_ping_datacenter(j->log, j->ip, j->port, j->session_key, j->service_type,
 		&j->rtt_us, &j->mtu_in, &j->mtu_out);
 	j->ok = (j->rtt_us > 0);
+	atomic_store(&j->done, 1);
 	if(atomic_exchange(&j->handoff, 1) == 1)
 		gk_ping_job_free(j); // owner already abandoned us — the job is ours to free
 	return NULL;
@@ -775,6 +777,7 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 			j->bw   = cc_json_int(dc, "maxBandwidth");
 			j->session_key   = strdup(c->lock_session_key ? c->lock_session_key : "");
 			j->service_type  = strdup(c->cfg->service_type ? c->cfg->service_type : "");
+			atomic_init(&j->done, 0);
 			atomic_init(&j->handoff, 0);
 			jobs[i] = j;
 			if(chiaki_thread_create(&threads[i], gk_ping_thread, j) == CHIAKI_ERR_SUCCESS)
@@ -782,35 +785,51 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 			else
 			{
 				gk_ping_thread(j); // fall back to inline if a thread won't start
-				// gk_ping_thread set handoff to 1 (returned 0 so it did NOT free).
-				// Discard our exchange result; collect loop sees joined=true and frees.
-				(void)atomic_exchange(&j->handoff, 1);
+				// gk_ping_thread set done+handoff (exchange returned 0, so it did NOT
+				// free); the collect loop treats the slot as complete and frees it.
 			}
 		}
+		// Phase 1: portable deadline wait. Poll each job's done flag instead of a
+		// timed join: the timed-join primitive is compiled out on macOS/iOS
+		// (undefined symbol once this object is linked) and on Android its
+		// pre-API-26 fallback is a plain blocking pthread_join that ignores the
+		// timeout, so the 15s deadline and cancel polling silently didn't work.
 		const uint64_t PING_DEADLINE_MS = 15000;
 		uint64_t waited = 0;
 		bool cancelled = false;
+		size_t remaining = 0;
+		for(size_t i = 0; i < n; i++)
+			if(jobs[i] && threaded[i] && !atomic_load(&jobs[i]->done))
+				remaining++;
+		while(remaining > 0 && waited < PING_DEADLINE_MS)
+		{
+			if(gk_cancelled(c)) { cancelled = true; break; }
+			CC_MS_SLEEP(100);
+			waited += 100;
+			remaining = 0;
+			for(size_t i = 0; i < n; i++)
+				if(jobs[i] && threaded[i] && !atomic_load(&jobs[i]->done))
+					remaining++;
+		}
+		// Phase 2: collect. Done jobs are joined (returns almost immediately: the
+		// job already signalled done) and their rows appended; unfinished jobs are
+		// detached and abandoned via the handoff exchange (whoever exchanges second
+		// frees the job).
 		for(size_t i = 0; i < n; i++)
 		{
 			if(!jobs[i]) continue; // allocation failed; row already appended
-			bool joined = !threaded[i]; // inline runs are already complete
-			while(threaded[i] && !joined && !cancelled && waited < PING_DEADLINE_MS)
+			bool done = !threaded[i] || atomic_load(&jobs[i]->done) != 0;
+			bool have_result = done;
+			if(done)
 			{
-				if(gk_cancelled(c)) { cancelled = true; break; }
-				if(chiaki_thread_timedjoin(&threads[i], NULL, 100) == CHIAKI_ERR_SUCCESS)
-					joined = true;
-				else
-					waited += 100;
+				if(threaded[i])
+					chiaki_thread_join(&threads[i], NULL); // returns almost immediately: job signalled done
 			}
-			bool have_result = joined;
-			if(!joined && threaded[i])
+			else
 			{
 				chiaki_thread_detach(&threads[i]);
 				if(atomic_exchange(&jobs[i]->handoff, 1) == 1)
-				{
-					have_result = true; // finished in the race window — results are valid, we free
-					joined = true;
-				}
+					have_result = true; // finished in the race window — results valid, we free (no join: detached)
 			}
 			if(have_result)
 			{

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -797,6 +797,7 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 		const uint64_t PING_DEADLINE_MS = 15000;
 		uint64_t waited = 0;
 		bool cancelled = false;
+		bool detached_any = false; // any thread abandoned (detached, not joined) -- see the threads[] free below
 		size_t remaining = 0;
 		for(size_t i = 0; i < n; i++)
 			if(jobs[i] && threaded[i] && !atomic_load(&jobs[i]->done))
@@ -828,6 +829,7 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 			else
 			{
 				chiaki_thread_detach(&threads[i]);
+				detached_any = true; // still running and NOT joined -> its threads[] slot must outlive this scope on Windows
 				if(atomic_exchange(&jobs[i]->handoff, 1) == 1)
 					have_result = true; // finished in the race window — results valid, we free (no join: detached)
 			}
@@ -856,7 +858,19 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 				CHIAKI_LOGI(c->log, "[GAIKAI] ping %s = abandoned (deadline/cancel)", cc_json_str(dc, "dataCenter"));
 			}
 		}
-		free(jobs); free(threads); free(threaded);
+		free(jobs); free(threaded);
+#ifdef _WIN32
+		// On Windows the OS thread wrapper writes thread->ret into its threads[] slot AFTER the
+		// ping body returns (thread.c win32_thread_func). A detached thread still running past the
+		// 15s deadline would then write into freed memory, so threads[] must not be freed when any
+		// slot was abandoned. Bounded, rare (one array, only when a datacenter hung past the
+		// deadline) -- leaked intentionally on that path.
+		if(!detached_any)
+			free(threads);
+#else
+		(void)detached_any; // POSIX ChiakiThread holds only pthread_t; nothing is written post-detach, safe to free
+		free(threads);
+#endif
 		if(cancelled)
 		{
 			json_object_put(dcs);

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -687,7 +687,20 @@ static struct json_object *gk_build_picker(GaikaiCtx *c, struct json_object *dcs
 			json_object_array_add(out, gk_ping_obj(name, 0, 0, 0,
 				cc_json_int(dc, "port"), cc_json_str(dc, "publicIp"), cc_json_int(dc, "maxBandwidth"), false));
 	}
-	if(prior) json_object_put(prior);
+	// Union: keep previously-persisted datacenters this title's API list doesn't offer
+	// (the old per-platform merge preserved them and their measured RTTs).
+	if(prior)
+	{
+		size_t pn = json_object_array_length(prior);
+		for(size_t i = 0; i < pn; i++)
+		{
+			struct json_object *prow = json_object_array_get_idx(prior, i);
+			const char *pname = cc_json_str(prow, "dataCenter");
+			if(*pname && !gk_find_dc(out, pname))
+				json_object_array_add(out, cc_json_clone(prow));
+		}
+		json_object_put(prior);
+	}
 	return out;
 }
 

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <strings.h>
-#include <unistd.h>
 #include <time.h>
 
 #define GK_BASE        "https://cc.prod.gaikai.com/v1"
@@ -77,7 +76,7 @@ static bool gk_sleep_cancellable(GaikaiCtx *c, int seconds)
 	for(int i = 0; i < seconds * 10; i++)
 	{
 		if(gk_cancelled(c)) return false;
-		usleep(100000);
+		CC_MS_SLEEP(100);
 	}
 	return true;
 }
@@ -238,9 +237,17 @@ static struct json_object *gk_build_spec(GaikaiCtx *c, const char *entitlement_i
 	char tz[16];
 	{
 		time_t t = time(NULL);
-		struct tm lt;
+		struct tm lt, gt;
+#ifdef _WIN32
+		// Windows CRT localtime/gmtime return per-thread storage — safe to copy out.
+		lt = *localtime(&t);
+		gt = *gmtime(&t);
+#else
 		localtime_r(&t, &lt);
-		long off = lt.tm_gmtoff;
+		gmtime_r(&t, &gt);
+#endif
+		gt.tm_isdst = lt.tm_isdst; // keep mktime from applying a DST delta twice
+		long off = (long)difftime(mktime(&lt), mktime(&gt));
 		int oh = (int)(off / 3600);
 		int om = (int)((off < 0 ? -off : off) % 3600) / 60;
 		snprintf(tz, sizeof(tz), "UTC%c%02d:%02d", off >= 0 ? '+' : '-', oh < 0 ? -oh : oh, om);

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -15,6 +15,7 @@
 // json-c: the specific headers come via cloudcatalog_internal.h (the umbrella
 // <json-c/json.h> is not present in the iOS/Android FetchContent build).
 
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -617,11 +618,18 @@ static int gk_cmp_rtt(const void *a, const void *b)
 typedef struct
 {
 	ChiakiLog *log;
-	const char *name, *ip;       // borrowed from the datacenters json (outlives the join)
+	char *name, *ip, *session_key, *service_type; // strdup'd — owned by the job
 	int port, bw;
-	const char *session_key, *service_type;
 	int64_t rtt_us; uint32_t mtu_in, mtu_out; bool ok;
+	atomic_int handoff; // 0 = thread running; first of {owner,thread} to exchange→1 must NOT free, second frees
 } GkPingJob;
+
+static void gk_ping_job_free(GkPingJob *j)
+{
+	if(!j) return;
+	free(j->name); free(j->ip); free(j->session_key); free(j->service_type);
+	free(j);
+}
 
 static void *gk_ping_thread(void *arg)
 {
@@ -630,6 +638,8 @@ static void *gk_ping_thread(void *arg)
 	cc_ping_datacenter(j->log, j->ip, j->port, j->session_key, j->service_type,
 		&j->rtt_us, &j->mtu_in, &j->mtu_out);
 	j->ok = (j->rtt_us > 0);
+	if(atomic_exchange(&j->handoff, 1) == 1)
+		gk_ping_job_free(j); // owner already abandoned us — the job is ours to free
 	return NULL;
 }
 
@@ -723,7 +733,7 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 		if(gk_cancelled(c)) { json_object_put(dcs); return CHIAKI_ERR_CANCELED; }
 
 		// Ping every datacenter in parallel (one thread each), then collect.
-		GkPingJob *jobs = (GkPingJob *)calloc(n, sizeof(GkPingJob));
+		GkPingJob **jobs = (GkPingJob **)calloc(n, sizeof(GkPingJob*));
 		ChiakiThread *threads = (ChiakiThread *)calloc(n, sizeof(ChiakiThread));
 		bool *threaded = (bool *)calloc(n, sizeof(bool)); // which slots actually started a thread
 		if(!jobs || !threads || !threaded)
@@ -735,33 +745,91 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 		for(size_t i = 0; i < n; i++)
 		{
 			struct json_object *dc = json_object_array_get_idx(dcs, i);
-			jobs[i].log = c->log;
-			jobs[i].name = cc_json_str(dc, "dataCenter");
-			jobs[i].ip = cc_json_str(dc, "publicIp");
-			jobs[i].port = cc_json_int(dc, "port");
-			jobs[i].bw = cc_json_int(dc, "maxBandwidth");
-			jobs[i].session_key = c->lock_session_key;
-			jobs[i].service_type = c->cfg->service_type;
-			if(chiaki_thread_create(&threads[i], gk_ping_thread, &jobs[i]) == CHIAKI_ERR_SUCCESS)
+			GkPingJob *j = (GkPingJob *)calloc(1, sizeof(GkPingJob));
+			if(!j)
+			{
+				// Allocation failed: skip this slot, append unmeasured row from dcs fields.
+				json_object_array_add(c->ping_results, gk_ping_obj(
+					cc_json_str(dc, "dataCenter"), 999, 0, 0,
+					cc_json_int(dc, "port"), cc_json_str(dc, "publicIp"),
+					cc_json_int(dc, "maxBandwidth"), false));
+				continue;
+			}
+			j->log = c->log;
+			j->name = strdup(cc_json_str(dc, "dataCenter"));
+			j->ip   = strdup(cc_json_str(dc, "publicIp"));
+			j->port = cc_json_int(dc, "port");
+			j->bw   = cc_json_int(dc, "maxBandwidth");
+			j->session_key   = strdup(c->lock_session_key ? c->lock_session_key : "");
+			j->service_type  = strdup(c->cfg->service_type ? c->cfg->service_type : "");
+			atomic_init(&j->handoff, 0);
+			jobs[i] = j;
+			if(chiaki_thread_create(&threads[i], gk_ping_thread, j) == CHIAKI_ERR_SUCCESS)
 				threaded[i] = true;
 			else
-				gk_ping_thread(&jobs[i]); // fall back to inline if a thread won't start
+			{
+				gk_ping_thread(j); // fall back to inline if a thread won't start
+				// gk_ping_thread set handoff to 1 (returned 0 so it did NOT free).
+				// Discard our exchange result; collect loop sees joined=true and frees.
+				(void)atomic_exchange(&j->handoff, 1);
+			}
 		}
+		const uint64_t PING_DEADLINE_MS = 15000;
+		uint64_t waited = 0;
+		bool cancelled = false;
 		for(size_t i = 0; i < n; i++)
 		{
-			if(threaded[i]) // only join slots whose thread started; a zeroed pthread_t join is UB
-				chiaki_thread_join(&threads[i], NULL);
-			if(jobs[i].ok)
-				json_object_array_add(c->ping_results, gk_ping_obj(jobs[i].name, (int)(jobs[i].rtt_us / 1000),
-					jobs[i].mtu_in, jobs[i].mtu_out, jobs[i].port, jobs[i].ip, jobs[i].bw, true));
+			if(!jobs[i]) continue; // allocation failed; row already appended
+			bool joined = !threaded[i]; // inline runs are already complete
+			while(threaded[i] && !joined && !cancelled && waited < PING_DEADLINE_MS)
+			{
+				if(gk_cancelled(c)) { cancelled = true; break; }
+				if(chiaki_thread_timedjoin(&threads[i], NULL, 100) == CHIAKI_ERR_SUCCESS)
+					joined = true;
+				else
+					waited += 100;
+			}
+			bool have_result = joined;
+			if(!joined && threaded[i])
+			{
+				chiaki_thread_detach(&threads[i]);
+				if(atomic_exchange(&jobs[i]->handoff, 1) == 1)
+				{
+					have_result = true; // finished in the race window — results are valid, we free
+					joined = true;
+				}
+			}
+			if(have_result)
+			{
+				GkPingJob *j = jobs[i];
+				if(j->ok)
+					json_object_array_add(c->ping_results, gk_ping_obj(j->name, (int)(j->rtt_us / 1000),
+						j->mtu_in, j->mtu_out, j->port, j->ip, j->bw, true));
+				else
+					json_object_array_add(c->ping_results, gk_ping_obj(j->name, 999, 0, 0, j->port, j->ip, j->bw, false));
+				if(j->ok)
+					CHIAKI_LOGI(c->log, "[GAIKAI] ping %s = %dms", j->name, (int)(j->rtt_us / 1000));
+				else
+					CHIAKI_LOGI(c->log, "[GAIKAI] ping %s = unreachable", j->name);
+				gk_ping_job_free(j);
+			}
 			else
-				json_object_array_add(c->ping_results, gk_ping_obj(jobs[i].name, 999, 0, 0, jobs[i].port, jobs[i].ip, jobs[i].bw, false));
-			if(jobs[i].ok)
-				CHIAKI_LOGI(c->log, "[GAIKAI] ping %s = %dms", jobs[i].name, (int)(jobs[i].rtt_us / 1000));
-			else
-				CHIAKI_LOGI(c->log, "[GAIKAI] ping %s = unreachable", jobs[i].name);
+			{
+				// Abandoned: the thread will free the job. Row from the dcs entry (outlives this loop).
+				struct json_object *dc = json_object_array_get_idx(dcs, i);
+				json_object_array_add(c->ping_results,
+					gk_ping_obj(cc_json_str(dc, "dataCenter"), 999, 0, 0,
+						cc_json_int(dc, "port"), cc_json_str(dc, "publicIp"),
+						cc_json_int(dc, "maxBandwidth"), false));
+				CHIAKI_LOGI(c->log, "[GAIKAI] ping %s = abandoned (deadline/cancel)", cc_json_str(dc, "dataCenter"));
+			}
 		}
 		free(jobs); free(threads); free(threaded);
+		if(cancelled)
+		{
+			json_object_put(dcs);
+			return CHIAKI_ERR_CANCELED;
+		}
 		// sort by RTT (skip the sort on OOM rather than crash -- leaves API order)
 		size_t rn = json_object_array_length(c->ping_results);
 		struct json_object **arr = (struct json_object **)malloc(rn * sizeof(*arr));

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -803,7 +803,14 @@ static ChiakiErrorCode gk_step12_select(GaikaiCtx *c)
 		c->selected_ping = json_object_array_get_idx(c->ping_results, 0); // lowest RTT
 		bool measured = cc_json_bool(c->selected_ping, "measured");
 		int rtt_ms = cc_json_int(c->selected_ping, "rtt");
-		if(measured && rtt_ms > 80)
+		if(!measured)
+		{
+			// Rows are RTT-sorted, so an unmeasured best row means no ping succeeded.
+			CHIAKI_LOGE(c->log, "[GAIKAI] all datacenter pings failed");
+			c->ping_timeout = true;
+			return CHIAKI_ERR_UNKNOWN; // ping-too-high / unreachable
+		}
+		if(rtt_ms > 80)
 		{
 			CHIAKI_LOGE(c->log, "[GAIKAI] best datacenter RTT %dms > 80ms", rtt_ms);
 			c->ping_timeout = true;

--- a/lib/src/cloudsession_internal.h
+++ b/lib/src/cloudsession_internal.h
@@ -10,9 +10,40 @@
 #include <chiaki/cloudsession.h>
 #include <chiaki/log.h>
 
+#include <ctype.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN // keep windows.h from dragging in winsock 1 / macro pollution
+#endif
+#include <windows.h>
+#define CC_MS_SLEEP(ms) Sleep(ms)
+#else
+#include <unistd.h>
+#define CC_MS_SLEEP(ms) usleep((ms) * 1000)
+#endif
+
+// Portable case-insensitive substring search (strcasestr is a GNU extension).
+static inline const char *cc_strcasestr(const char *haystack, const char *needle)
+{
+	if(!haystack || !needle || !*needle)
+		return haystack;
+	size_t nlen = strlen(needle);
+	for(; *haystack; haystack++)
+	{
+		size_t i = 0;
+		while(i < nlen && haystack[i]
+			&& tolower((unsigned char)haystack[i]) == tolower((unsigned char)needle[i]))
+			i++;
+		if(i == nlen)
+			return haystack;
+	}
+	return NULL;
+}
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/src/cloudsession_kamaji.c
+++ b/lib/src/cloudsession_kamaji.c
@@ -250,7 +250,7 @@ static bool km_pick_fullgame(KamajiCtx *c, struct json_object *sku, bool require
 	return true;
 }
 
-static ChiakiErrorCode km_step0_5d_resolve(KamajiCtx *c)
+static ChiakiErrorCode km_step0_5d_resolve(KamajiCtx *c, char **out_error)
 {
 	if(c->cfg->progress) c->cfg->progress("Resolving Game - Step 2 of 5", c->cfg->user);
 	const char *country = (c->cfg->store_country && *c->cfg->store_country) ? c->cfg->store_country : "US";
@@ -270,6 +270,12 @@ static ChiakiErrorCode km_step0_5d_resolve(KamajiCtx *c)
 	if(resp.status_code == 404)
 	{
 		CHIAKI_LOGE(c->log, "[KAMAJI] 0.5d product not found (404)");
+		if(out_error)
+		{
+			char b[256];
+			snprintf(b, sizeof(b), "Game not found: Product ID '%s' does not exist or is not available for cloud streaming", c->cfg->game_identifier);
+			*out_error = strdup(b);
+		}
 		cc_http_response_fini(&resp);
 		return CHIAKI_ERR_UNKNOWN;
 	}
@@ -330,7 +336,17 @@ static ChiakiErrorCode km_step0_5d_resolve(KamajiCtx *c)
 	c->scopes = (strcmp(c->platform, "ps3") == 0) ? KM_PS3_SCOPES : KM_PS4_SCOPES;
 	json_object_put(obj);
 
-	if(!c->entitlement_id[0]) { CHIAKI_LOGE(c->log, "[KAMAJI] 0.5d no entitlement resolved"); return CHIAKI_ERR_UNKNOWN; }
+	if(!c->entitlement_id[0])
+	{
+		CHIAKI_LOGE(c->log, "[KAMAJI] 0.5d no entitlement resolved");
+		if(out_error)
+		{
+			char b[256];
+			snprintf(b, sizeof(b), "Could not determine Entitlement ID from Product ID '%s'. Game may not be available for cloud streaming.", c->cfg->game_identifier);
+			*out_error = strdup(b);
+		}
+		return CHIAKI_ERR_UNKNOWN;
+	}
 	CHIAKI_LOGI(c->log, "[KAMAJI] 0.5d -> entitlement %s platform %s sku %s", c->entitlement_id, c->platform, c->streaming_sku);
 	return CHIAKI_ERR_SUCCESS;
 }
@@ -630,7 +646,7 @@ ChiakiErrorCode cc_kamaji_resolve(ChiakiLog *log,
 		e = km_step0_5b_anon_authcode(&c, &anon_code);
 		if(e == CHIAKI_ERR_SUCCESS) e = km_step0_5c_anon_session(&c, anon_code);
 		free(anon_code);
-		if(e == CHIAKI_ERR_SUCCESS) e = km_step0_5d_resolve(&c);
+		if(e == CHIAKI_ERR_SUCCESS) e = km_step0_5d_resolve(&c, out_error);
 		if(e == CHIAKI_ERR_SUCCESS) e = km_step0_5e_check_acquire(&c, out_error);
 	}
 

--- a/lib/src/cloudsession_kamaji.c
+++ b/lib/src/cloudsession_kamaji.c
@@ -322,9 +322,9 @@ static ChiakiErrorCode km_step0_5d_resolve(KamajiCtx *c)
 	{
 		const char *s = json_object_get_string(json_object_array_get_idx(pp, i));
 		if(!s) continue;
-		if(strcasestr(s, "PS5")) ps5 = true;
-		else if(strcasestr(s, "PS4")) ps4 = true;
-		else if(strcasestr(s, "PS3")) ps3 = true;
+		if(cc_strcasestr(s, "PS5")) ps5 = true;
+		else if(cc_strcasestr(s, "PS4")) ps4 = true;
+		else if(cc_strcasestr(s, "PS3")) ps3 = true;
 	}
 	snprintf(c->platform, sizeof(c->platform), "%s", ps5 ? "ps5" : (ps4 ? "ps4" : (ps3 ? "ps3" : "ps4")));
 	c->scopes = (strcmp(c->platform, "ps3") == 0) ? KM_PS3_SCOPES : KM_PS4_SCOPES;

--- a/lib/src/ios_bridge_helpers.c
+++ b/lib/src/ios_bridge_helpers.c
@@ -2,6 +2,7 @@
 // iOS bridge helpers - see ios_bridge_helpers.h for rationale.
 
 #include <chiaki/ios_bridge_helpers.h>
+#include <chiaki/streamconnection.h> // F5 thread-safe video metric accessors
 
 CHIAKI_EXPORT size_t chiaki_session_get_sizeof(void)
 {
@@ -82,15 +83,14 @@ CHIAKI_EXPORT void chiaki_session_get_stream_metrics_ex(ChiakiSession *session,
 		v_loss = sc->congestion_control.packet_loss;
 		v_fps = sc->measured_fps;
 		v_rtt = sc->measured_rtt_ms;
-		ChiakiVideoReceiver *vr = sc->video_receiver;
-		if(vr)
+		// Thread-safe reads (state_mutex-guarded): the takion thread can free video_receiver
+		// during teardown while this metrics poll runs on another thread (F5).
+		v_drops = chiaki_stream_connection_video_frames_lost(sc);
+		unsigned int rw = 0, rh = 0;
+		if(chiaki_stream_connection_video_resolution(sc, &rw, &rh))
 		{
-			v_drops = vr->cumulative_frames_lost;
-			if(vr->profile_cur >= 0 && (size_t)vr->profile_cur < vr->profiles_count)
-			{
-				v_w = (int)vr->profiles[vr->profile_cur].width;
-				v_h = (int)vr->profiles[vr->profile_cur].height;
-			}
+			v_w = (int)rw;
+			v_h = (int)rh;
 		}
 		// Fall back to the requested profile before the first adaptive profile is selected.
 		if(v_w == 0 || v_h == 0)

--- a/lib/src/streamconnection.c
+++ b/lib/src/streamconnection.c
@@ -452,6 +452,14 @@ CHIAKI_EXPORT bool chiaki_stream_connection_video_resolution(ChiakiStreamConnect
 	return ok;
 }
 
+CHIAKI_EXPORT uint64_t chiaki_stream_connection_video_frames_lost(ChiakiStreamConnection *stream_connection)
+{
+	chiaki_mutex_lock(&stream_connection->state_mutex);
+	uint64_t v = stream_connection->video_receiver ? stream_connection->video_receiver->cumulative_frames_lost : 0;
+	chiaki_mutex_unlock(&stream_connection->state_mutex);
+	return v;
+}
+
 static void stream_connection_takion_cb(ChiakiTakionEvent *event, void *user)
 {
 	ChiakiStreamConnection *stream_connection = user;

--- a/lib/src/streamconnection.c
+++ b/lib/src/streamconnection.c
@@ -432,6 +432,26 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_stream_connection_stop(ChiakiStreamConnecti
 	return err == CHIAKI_ERR_SUCCESS ? unlock_err : err;
 }
 
+CHIAKI_EXPORT bool chiaki_stream_connection_video_resolution(ChiakiStreamConnection *stream_connection,
+		unsigned int *width, unsigned int *height)
+{
+	bool ok = false;
+	chiaki_mutex_lock(&stream_connection->state_mutex);
+	ChiakiVideoReceiver *vr = stream_connection->video_receiver;
+	if(vr)
+	{
+		int pc = vr->profile_cur; // snapshot: written by the takion thread on adaptive switch
+		if(pc >= 0 && (size_t)pc < vr->profiles_count)
+		{
+			*width = vr->profiles[pc].width;
+			*height = vr->profiles[pc].height;
+			ok = true;
+		}
+	}
+	chiaki_mutex_unlock(&stream_connection->state_mutex);
+	return ok;
+}
+
 static void stream_connection_takion_cb(ChiakiTakionEvent *event, void *user)
 {
 	ChiakiStreamConnection *stream_connection = user;

--- a/lib/src/thread.c
+++ b/lib/src/thread.c
@@ -72,6 +72,21 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_join(ChiakiThread *thread, void **re
 	return CHIAKI_ERR_SUCCESS;
 }
 
+CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_detach(ChiakiThread *thread)
+{
+#if _WIN32
+	// On Windows the thread function owns the HANDLE; close it so the OS can reclaim
+	// resources when the thread exits, analogous to pthread_detach.
+	CloseHandle(thread->thread);
+	thread->thread = NULL;
+#else
+	int r = pthread_detach(thread->thread);
+	if(r != 0)
+		return CHIAKI_ERR_THREAD;
+#endif
+	return CHIAKI_ERR_SUCCESS;
+}
+
 //#define CHIAKI_WINDOWS_THREAD_NAME
 
 CHIAKI_EXPORT ChiakiErrorCode chiaki_thread_set_name(ChiakiThread *thread, const char *name)

--- a/test/cloudcatalog_merge.c
+++ b/test/cloudcatalog_merge.c
@@ -320,6 +320,20 @@ static MunitResult test_parse_container_store_locale(const MunitParameter p[], v
 	return MUNIT_OK;
 }
 
+static MunitResult test_stable_key(const MunitParameter params[], void *user)
+{
+	(void)params; (void)user;
+	char out[128];
+	munit_assert_string_equal(
+		cc_stable_key("UP9000-CUSA00552_00-GODOFWAR3HDGAME0", out, sizeof(out)),
+		"UP9000|CUSA00552|00");
+	munit_assert_string_equal(cc_stable_key("A-B-C", out, sizeof(out)), "A|B");
+	munit_assert_string_equal(cc_stable_key("SINGLETOKEN", out, sizeof(out)), "");
+	munit_assert_string_equal(cc_stable_key("", out, sizeof(out)), "");
+	munit_assert_string_equal(cc_stable_key(NULL, out, sizeof(out)), "");
+	return MUNIT_OK;
+}
+
 MunitTest tests_cloudcatalog_merge[] = {
 	{ "/apollo_dedup", test_apollo_dedup, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/device_based_ps5", test_device_based_ps5, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
@@ -328,5 +342,6 @@ MunitTest tests_cloudcatalog_merge[] = {
 	{ "/sort_and_envelope", test_sort_and_envelope, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/cloud_language_helpers", test_cloud_language_helpers, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/parse_container_store_locale", test_parse_container_store_locale, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/stable_key", test_stable_key, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };


### PR DESCRIPTION
Fixes the 8 bugs and 10 cleanups surfaced by the code review of the cloud-provisioning consolidation on `release/beta`. One commit per finding.

## Bugs (F1–F8)
- **F1** — profile switch left `CloudStreamingBackend` holding a freed `Settings` pointer (use-after-free); rebind it in `profileChanged()`.
- **F2** — `stable_key()` nested `strtok()` always returned `""`, silently disabling the owned-game stable-key match tier. Fixed + unit test.
- **F3** — Windows build break: `tm_gmtoff` / `strcasestr` / `usleep` guarded for non-glibc (mingw) targets.
- **F4** — QJSValue was copied/destroyed on a detached worker thread (heap-corruption risk) and `invokeMethod(this,…)` could hit a freed backend; marshal through the GUI thread via `QPointer`.
- **F5** — stats overlay read `video_receiver->profiles[]` from the GUI/JNI thread with no lock, racing session teardown (UAF); added a mutex-guarded accessor used by Qt + Android.
- **F6** — when every datacenter ping failed the `>80ms` gate was skipped and `rtt:999` was sent downstream; now fails deterministically with the ping-timeout path.
- **F7** — PSNOW loading-screen artwork read the dead `psnow_catalog` cache key (always blank); read `unified_catalog_v3`.
- **F8** — restored the 15s overall ping deadline + cancellation and reworked ping-thread ownership (atomic handoff) so abandoned threads can't touch freed memory. Uses a portable done-flag poll (the timed-join primitive is compiled out on macOS/iOS and no-ops pre-API-26 on Android).

## Cleanups (M1–M10)
Inter-request cooldowns + don't cache an incomplete PSNOW catalog (M1); persist a passed account-attributes check (M2); restore "Game not found" resolve messages (M3); union-merge prior datacenters (M4); honor the NULL-config contract (M5); 64-bit cache-age math (M6); json fallback-array leaks (M7); Android `activity?` vs `requireActivity()` crash guard (M8); Qt + iOS dead-code removal (M9/M10).

## Verification
libchiaki unit suite green (incl. new `stable_key` test); real-script builds pass on macOS (Qt), iOS (simulator), and Android. On-device Android E2E (Pixel 6) + forced error/edge-branch coverage in Qt confirmed F5/F6/F7/F8 and M1/M3/M4/M5/M7 by execution. Regression hunting (sanitizer run, catalog diff vs base) is still in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
