### PR TITLE
Full controller support: DualSense parity across Qt, Android, and iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ lib/test_cloudcatalog/.npsso
 
 # iOS build/run logs (build artifacts, never track)
 ios/logs/
+
+# Local scratch: build + logcat captures (may contain PSN session tokens) -- never track
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ macos/fastlane/report.xml
 scripts/flatpak/test-flatpak-local.sh
 pylux-test.flatpak
 lib/test_cloudcatalog/.npsso
+
+# iOS build/run logs (build artifacts, never track)
+ios/logs/

--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,5 @@ lib/test_cloudcatalog/.npsso
 ios/logs/
 
 # Local scratch: build + logcat captures (may contain PSN session tokens) -- never track
-tmp/
+# (anchored to the repo root so legitimate nested tmp/ dirs aren't swallowed)
+/tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# Pylux — agent guide
+
+Pylux is a cross-platform PS4/PS5 Remote Play + Internet/Cloud Play client (fork of
+[chiaki-ng](https://github.com/streetpea/chiaki-ng)): shared C library (`lib/`), Qt desktop
+(`gui/` — macOS/Windows/Linux/Steam Deck), Android (`android/`), iOS (`ios/`).
+
+## Architecture
+- **DO** put protocol, streaming, catalog, and feature logic in the shared C (`lib/`) so every
+  platform gets it and stays consistent. Platforms only map inputs/outputs (controllers,
+  audio, video, UI).
+- **DON'T** patch shared behavior in one platform. If a fix would need repeating per platform,
+  it belongs in `lib/`.
+- **DO** debug cross-platform discrepancies empirically: capture runtime logs on a working and
+  a broken platform and diff them, and diff suspect files against `upstream/main` (remote is
+  configured).
+- **DON'T** make sweeping edits to upstream-owned Qt files; prefer new files so chiaki-ng
+  fixes stay cherry-pickable.
+
+## Workflow
+- Feature branches off `master`. PRs target **`release/beta`**, which auto-builds and deploys
+  BETA to all stores on merge. `master` deploys to production. **DON'T** push to release
+  branches casually.
+
+## Data handling: title IDs, product IDs, entitlements
+- **DON'T** infer prefix/regex patterns from the ID samples you happen to see. PSN IDs are
+  region- and account-dependent; a pattern that fits one library corrupts matching for others.
+- **DO** match structurally: split on `-`/`_` and drop the region-varying tail, via
+  `cc_stable_key()` in `lib/src/cloudcatalog_merge.c` (see also `normalize_apollo_game` /
+  `normalize_title` there). Extend those helpers; don't add ad-hoc string checks elsewhere.
+
+## Build / run / verify
+- **DO** use the build scripts and read their headers first — they are self-documenting:
+  - macOS (Qt): `./scripts/build-macos.sh arm64 --iterate --skip-deps --ad-hoc
+    --no-credentials-file --skip-notary-keychain --no-steamworks`; run `build-output/Pylux.app`
+    only; logs in `tmp/pylux-macos.log` (`logs` subcommand).
+  - iOS: `./ios/build.sh dev|iterate|launch|logs|stop-logs` (+`PYLUX_FULL_BUILD=1` when the C
+    lib changed). Device logs stream over Wi-Fi into `ios/logs/pylux.log`; app relaunch =
+    capture relaunch.
+  - Android: `android/build.ps1` / `android/build-local.sh`.
+- **DON'T** improvise around the scripts (custom launch paths, alternate log tools, manual
+  bundle surgery, `idevicesyslog`, requiring USB for iOS logs, TERM-ing the iOS log capture —
+  `stop-logs` handles it).
+- **DO** verify changes by running on the real platform and reading its logs; compiling is not
+  verification.
+
+## iOS ↔ C library boundary
+`ChiakiSession`'s memory layout depends on the lib's CMake config; Xcode compiles ObjC/Swift
+without that config, so struct offsets differ between the two sides.
+- **DON'T** call `static inline` chiaki functions that touch struct fields from `ios/Pylux/**`
+  (e.g. the `chiaki_session_set_*` sink/callback setters) — the write lands at the wrong
+  offset and silently no-ops. `ios/build.sh` fails the build on violations
+  (`check_forbidden_inline_setters`).
+- **DO** use the `CHIAKI_EXPORT` `_ex` wrappers in `lib/src/ios_bridge_helpers.c`, adding a
+  wrapper there whenever the lib gains a setter iOS needs, and allocate `ChiakiSession` via
+  `chiaki_session_get_sizeof()`, never `sizeof`.
+
+## How the system works (non-obvious facts to respect)
+- PS5 Remote Play delivers rumble ONLY as DualSense haptic audio: the client must set
+  `enable_dualsense=true` and register a haptics sink (on iOS via
+  `chiaki_session_set_haptics_sink_ex`). Cloud rumble uses classic rumble events — cloud
+  working says nothing about Remote Play.
+- Qt keyboard/controller navigation relies on `Qt::TabFocusAllControls` (gui main.cpp) and
+  dialogs overriding `seedFocus()`; don't add competing `forceActiveFocus` calls.
+- iOS binds the Create/PS controller buttons to system gestures by default;
+  `StreamInput.attachController` claims them with `preferredSystemGestureState = .disabled`.

--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -761,7 +761,10 @@ JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject 
 
 	// DualSense haptic-audio -> motor rumble (see android_chiaki_haptics_frame_cb).
 	// Required because enable_dualsense=true makes the PS5 deliver rumble as haptic audio.
-	ChiakiAudioSink haptics_sink;
+	// Zero-init: ChiakiAudioSink also has a header_cb member; leaving it as stack
+	// garbage plants a wild function pointer in the session for any future code
+	// that dispatches headers to the haptics sink.
+	ChiakiAudioSink haptics_sink = { 0 };
 	haptics_sink.user = session;
 	haptics_sink.frame_cb = android_chiaki_haptics_frame_cb;
 	chiaki_session_set_haptics_sink(&session->session, &haptics_sink);

--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -209,6 +209,7 @@ typedef struct android_chiaki_session_t
 	jmethodID java_session_event_rumble_meth;
 	jmethodID java_session_event_regist_meth;
 	jmethodID java_session_event_holepunch_meth;
+	jmethodID java_session_event_ps_chord_meth;
 	// Cached class refs for CHIAKI_EVENT_REGIST (FindClass doesn't work from native threads)
 	jclass java_target_class;
 	jmethodID java_target_from_value;
@@ -241,6 +242,7 @@ typedef struct android_chiaki_session_t
 	AndroidChiakiOpusDecoder opus_decoder;
 	bool use_opus_decoder; // true for PSCloud, false for PSNow/Remote Play
 	void *audio_output;
+	uint8_t last_haptic_amp; // last haptic-audio-derived rumble amplitude emitted (throttle)
 } AndroidChiakiSession;
 
 static void android_chiaki_event_cb(ChiakiEvent *event, void *user)
@@ -311,6 +313,12 @@ static void android_chiaki_event_cb(ChiakiEvent *event, void *user)
 			E->CallVoidMethod(env, session->java_session,
 							  session->java_session_event_holepunch_meth);
 			break;
+		case CHIAKI_EVENT_PS_CHORD:
+			// OPTIONS+SHARE chord fired: PS pulse already went to the console;
+			// tell Kotlin so the activity can also surface its in-stream menu.
+			E->CallVoidMethod(env, session->java_session,
+							  session->java_session_event_ps_chord_meth);
+			break;
 		case CHIAKI_EVENT_TRIGGER_EFFECTS:
 		case CHIAKI_EVENT_HAPTIC_INTENSITY:
 		case CHIAKI_EVENT_TRIGGER_INTENSITY:
@@ -330,6 +338,41 @@ static void android_chiaki_event_cb(ChiakiEvent *event, void *user)
 	}
 
 	(*global_vm)->DetachCurrentThread(global_vm);
+}
+
+// With enable_dualsense=true a PS5 streams rumble as DualSense haptic-audio PCM
+// (interleaved stereo int16) rather than classic rumble packets. Android can't play
+// rich body haptics, so -- like Qt and iOS -- collapse each frame to a single motor
+// amplitude and re-emit it through the normal rumble path (android_chiaki_event_cb ->
+// eventRumble -> vibrator). Throttled to amplitude changes so we don't churn the JVM.
+static void android_chiaki_haptics_frame_cb(uint8_t *buf, size_t buf_size, void *user)
+{
+	AndroidChiakiSession *session = user;
+	if(!buf)
+		return;
+	const size_t sample_size = 2 * sizeof(int16_t); // interleaved stereo int16
+	size_t n = buf_size / sample_size;
+	if(n == 0)
+		return;
+	uint64_t sum = 0;
+	for(size_t i = 0; i < n; i++)
+	{
+		int16_t l = 0, r = 0;
+		memcpy(&l, buf + i * sample_size, sizeof(int16_t));
+		memcpy(&r, buf + i * sample_size + sizeof(int16_t), sizeof(int16_t));
+		int al = l < 0 ? -l : l, ar = r < 0 ? -r : r;
+		sum += (uint64_t)(al > ar ? al : ar);
+	}
+	uint32_t avg = (uint32_t)(sum / n); // 0..32767
+	uint8_t amp = avg >= 32767 ? 255 : (uint8_t)((avg * 255) / 32767);
+	if(amp == session->last_haptic_amp)
+		return; // only emit on meaningful change
+	session->last_haptic_amp = amp;
+	ChiakiEvent event = { 0 };
+	event.type = CHIAKI_EVENT_RUMBLE;
+	event.rumble.left = amp;
+	event.rumble.right = amp;
+	android_chiaki_event_cb(&event, session); // reuse the existing rumble dispatch
 }
 
 JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject result, jobject connect_info_obj, jstring log_file_str, jboolean log_verbose, jobject java_session)
@@ -355,10 +398,15 @@ JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject 
 	jclass connect_video_profile_class = E->GetObjectClass(env, connect_video_profile_obj);
 
 	ChiakiConnectInfo connect_info = { 0 };
-	// enable_dualsense stays false (zero-init) on Android BY DESIGN: with it off
-	// the console sends classic rumble events (which Android can deliver) instead
-	// of DualSense audio-haptics / adaptive-trigger data, for which Android has no
-	// public API. See the feedback-event switch in event_cb() for details.
+	// enable_dualsense=true so a PS5 sends rumble at all in Remote Play. With it OFF an
+	// RP PS5 delivers rumble ONLY as DualSense haptic audio (a DualShock4-declared client
+	// never gets classic type-7 rumble packets -- confirmed on-device: only type-9
+	// PAD_INFO arrives, which carries no motor data), so RP rumble was silent while Cloud
+	// still worked. We can't play rich body haptics or adaptive triggers on Android (no
+	// public API -- those events stay ignored), but the haptics sink registered below
+	// converts the haptic-audio PCM to one motor amplitude and re-emits it as a normal
+	// rumble event (same approach as Qt/iOS), so rumble works for both RP and Cloud.
+	connect_info.enable_dualsense = true;
 	connect_info.ps5 = ps5;
 
 	const char *str_borrow = E->GetStringUTFChars(env, host_string, NULL);
@@ -610,6 +658,7 @@ JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject 
 	session->java_session_event_rumble_meth = E->GetMethodID(env, session->java_session_class, "eventRumble", "(II)V");
 	session->java_session_event_regist_meth = E->GetMethodID(env, session->java_session_class, "eventRegist", "(L"BASE_PACKAGE"/RegistHost;)V");
 	session->java_session_event_holepunch_meth = E->GetMethodID(env, session->java_session_class, "eventHolepunch", "()V");
+	session->java_session_event_ps_chord_meth = E->GetMethodID(env, session->java_session_class, "eventPsChord", "()V");
 
 	// Cache class refs for CHIAKI_EVENT_REGIST (FindClass won't work from native threads)
 	session->java_target_class = E->NewGlobalRef(env, E->FindClass(env, BASE_PACKAGE"/Target"));
@@ -662,6 +711,13 @@ JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject 
 	else
 		android_chiaki_audio_decoder_get_sink(&session->audio_decoder, &audio_sink);
 	chiaki_session_set_audio_sink(&session->session, &audio_sink);
+
+	// DualSense haptic-audio -> motor rumble (see android_chiaki_haptics_frame_cb).
+	// Required because enable_dualsense=true makes the PS5 deliver rumble as haptic audio.
+	ChiakiAudioSink haptics_sink;
+	haptics_sink.user = session;
+	haptics_sink.frame_cb = android_chiaki_haptics_frame_cb;
+	chiaki_session_set_haptics_sink(&session->session, &haptics_sink);
 
 beach:
 	if(!session && log)

--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -14,6 +14,7 @@
 #include <chiaki/base64.h>
 #include <chiaki/cloudcatalog.h>
 #include <chiaki/cloudsession.h>
+#include <chiaki/orientation.h>
 
 #include <string.h>
 #include <stdlib.h>
@@ -186,6 +187,52 @@ JNIEXPORT jstring JNICALL JNI_FCN(quitReasonToString)(JNIEnv *env, jobject obj, 
 JNIEXPORT jboolean JNICALL JNI_FCN(quitReasonIsError)(JNIEnv *env, jobject obj, jint value)
 {
 	return chiaki_quit_reason_is_error(value);
+}
+
+// --- Orientation tracker (controller gyro -> orientation quaternion) ---
+// Thin wrappers around the shared Madgwick tracker (lib/src/orientation.c) so the
+// Kotlin controller-motion path computes orientation with the SAME algorithm as
+// Qt (SDL sensors) and iOS (GCMotion), instead of duplicating it in Kotlin.
+// Controller sensors on Android (InputDevice.getSensorManager, API 31+) provide
+// only gyro/accel -- no rotation vector -- hence the tracker.
+
+JNIEXPORT jlong JNICALL JNI_FCN(orientationTrackerCreate)(JNIEnv *env, jobject obj)
+{
+	ChiakiOrientationTracker *tracker = malloc(sizeof(ChiakiOrientationTracker));
+	if(!tracker)
+		return 0;
+	chiaki_orientation_tracker_init(tracker);
+	return (jlong)(uintptr_t)tracker;
+}
+
+JNIEXPORT void JNICALL JNI_FCN(orientationTrackerFree)(JNIEnv *env, jobject obj, jlong ptr)
+{
+	free((ChiakiOrientationTracker *)(uintptr_t)ptr);
+}
+
+/**
+ * Feed one gyro (rad/s) + accel (G) sample and return the tracked state:
+ * out[0..2] = gyro, out[3..5] = accel, out[6..9] = orientation quaternion x/y/z/w
+ * (as chiaki_orientation_tracker_apply_to_controller_state would write them).
+ */
+JNIEXPORT void JNICALL JNI_FCN(orientationTrackerUpdate)(JNIEnv *env, jobject obj, jlong ptr,
+	jfloat gx, jfloat gy, jfloat gz, jfloat ax, jfloat ay, jfloat az, jlong timestamp_us, jfloatArray out)
+{
+	ChiakiOrientationTracker *tracker = (ChiakiOrientationTracker *)(uintptr_t)ptr;
+	if(!tracker)
+		return;
+	ChiakiAccelNewZero accel_zero;
+	chiaki_accel_new_zero_set_inactive(&accel_zero, false);
+	chiaki_orientation_tracker_update(tracker, gx, gy, gz, ax, ay, az, &accel_zero, true, (uint32_t)timestamp_us);
+	ChiakiControllerState state;
+	chiaki_controller_state_set_idle(&state);
+	chiaki_orientation_tracker_apply_to_controller_state(tracker, &state);
+	jfloat vals[10] = {
+		state.gyro_x, state.gyro_y, state.gyro_z,
+		state.accel_x, state.accel_y, state.accel_z,
+		state.orient_x, state.orient_y, state.orient_z, state.orient_w,
+	};
+	(*env)->SetFloatArrayRegion(env, out, 0, 10, vals);
 }
 
 JNIEXPORT jobject JNICALL JNI_FCN(videoProfilePreset)(JNIEnv *env, jobject obj, jint resolution_preset, jint fps_preset, jobject codec)

--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -311,6 +311,20 @@ static void android_chiaki_event_cb(ChiakiEvent *event, void *user)
 			E->CallVoidMethod(env, session->java_session,
 							  session->java_session_event_holepunch_meth);
 			break;
+		case CHIAKI_EVENT_TRIGGER_EFFECTS:
+		case CHIAKI_EVENT_HAPTIC_INTENSITY:
+		case CHIAKI_EVENT_TRIGGER_INTENSITY:
+		case CHIAKI_EVENT_LED_COLOR:
+		case CHIAKI_EVENT_PLAYER_INDEX:
+		case CHIAKI_EVENT_MOTION_RESET:
+			// Intentionally unhandled on Android: DualSense adaptive triggers and
+			// audio haptics have no public Android API (they are only reachable via
+			// raw USB/BT HID output reports, which we deliberately do not do), and
+			// the same goes for controller LED / player-index. enable_dualsense
+			// stays false in the Android connect info, so the console keeps sending
+			// classic CHIAKI_EVENT_RUMBLE (handled above) instead of DualSense-only
+			// feedback this platform cannot deliver.
+			break;
 		default:
 			break;
 	}
@@ -341,6 +355,10 @@ JNIEXPORT void JNICALL JNI_FCN(sessionCreate)(JNIEnv *env, jobject obj, jobject 
 	jclass connect_video_profile_class = E->GetObjectClass(env, connect_video_profile_obj);
 
 	ChiakiConnectInfo connect_info = { 0 };
+	// enable_dualsense stays false (zero-init) on Android BY DESIGN: with it off
+	// the console sends classic rumble events (which Android can deliver) instead
+	// of DualSense audio-haptics / adaptive-trigger data, for which Android has no
+	// public API. See the feedback-event switch in event_cb() for details.
 	connect_info.ps5 = ps5;
 
 	const char *str_borrow = E->GetStringUTFChars(env, host_string, NULL);
@@ -787,6 +805,14 @@ JNIEXPORT void JNICALL JNI_FCN(sessionSetControllerState)(JNIEnv *env, jobject o
 	controller_state.orient_z = E->GetFloatField(env, controller_state_java, session->java_controller_state_orient_z);
 	controller_state.orient_w = E->GetFloatField(env, controller_state_java, session->java_controller_state_orient_w);
 	chiaki_session_set_controller_state(&session->session, &controller_state);
+}
+
+JNIEXPORT void JNICALL JNI_FCN(sessionSetPsChord)(JNIEnv *env, jobject obj, jlong ptr, jboolean enabled, jint hold_ms)
+{
+	AndroidChiakiSession *session = (AndroidChiakiSession *)ptr;
+	if(!session)
+		return;
+	chiaki_session_set_ps_chord(&session->session, enabled, hold_ms > 0 ? (uint32_t)hold_ms : 0);
 }
 
 JNIEXPORT void JNICALL JNI_FCN(sessionSetLoginPin)(JNIEnv *env, jobject obj, jlong ptr, jstring pin_java)

--- a/android/app/src/main/cpp/chiaki-jni.c
+++ b/android/app/src/main/cpp/chiaki-jni.c
@@ -290,6 +290,7 @@ typedef struct android_chiaki_session_t
 	bool use_opus_decoder; // true for PSCloud, false for PSNow/Remote Play
 	void *audio_output;
 	uint8_t last_haptic_amp; // last haptic-audio-derived rumble amplitude emitted (throttle)
+	uint16_t haptic_same_amp_frames; // consecutive frames suppressed by the throttle
 } AndroidChiakiSession;
 
 static void android_chiaki_event_cb(ChiakiEvent *event, void *user)
@@ -412,8 +413,16 @@ static void android_chiaki_haptics_frame_cb(uint8_t *buf, size_t buf_size, void 
 	}
 	uint32_t avg = (uint32_t)(sum / n); // 0..32767
 	uint8_t amp = avg >= 32767 ? 255 : (uint8_t)((avg * 255) / 32767);
+	// Only emit on change -- but the consumer plays a FINITE (1s) effect, so a
+	// constant non-zero amplitude sustained past that would go silent. Let equal
+	// amplitudes through periodically to re-arm the effect (~every 0.5s at the
+	// ~100 frames/s haptic rate).
 	if(amp == session->last_haptic_amp)
-		return; // only emit on meaningful change
+	{
+		if(amp == 0 || ++session->haptic_same_amp_frames < 50)
+			return;
+	}
+	session->haptic_same_amp_frames = 0;
 	session->last_haptic_amp = amp;
 	ChiakiEvent event = { 0 };
 	event.type = CHIAKI_EVENT_RUMBLE;

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -58,6 +58,9 @@ class Preferences(context: Context)
 		const val DPAD_TOUCH_INCREMENT_MIN = 1
 		const val DPAD_TOUCH_INCREMENT_MAX = 1079
 		const val DPAD_TOUCH_INCREMENT_DEFAULT = 30
+		const val RUMBLE_INTENSITY_MIN = 0
+		const val RUMBLE_INTENSITY_MAX = 500
+		const val RUMBLE_INTENSITY_DEFAULT = 100
 		const val DPAD_TOUCH_SHORTCUT1_DEFAULT = 9
 		const val DPAD_TOUCH_SHORTCUT2_DEFAULT = 10
 		const val DPAD_TOUCH_SHORTCUT3_DEFAULT = 7
@@ -103,6 +106,12 @@ class Preferences(context: Context)
 	var rumbleEnabled
 		get() = sharedPreferences.getBoolean(rumbleEnabledKey, true)
 		set(value) { sharedPreferences.edit().putBoolean(rumbleEnabledKey, value).apply() }
+
+	val rumbleIntensityKey get() = resources.getString(R.string.preferences_rumble_intensity_key)
+	var rumbleIntensity // percent, 0..500 (100 = 1x). Applied at stream start.
+		get() = sharedPreferences.getInt(rumbleIntensityKey, RUMBLE_INTENSITY_DEFAULT)
+			.coerceIn(RUMBLE_INTENSITY_MIN, RUMBLE_INTENSITY_MAX)
+		set(value) { sharedPreferences.edit().putInt(rumbleIntensityKey, value.coerceIn(RUMBLE_INTENSITY_MIN, RUMBLE_INTENSITY_MAX)).apply() }
 
 	val motionEnabledKey get() = resources.getString(R.string.preferences_motion_enabled_key)
 	var motionEnabled

--- a/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/common/Preferences.kt
@@ -113,10 +113,32 @@ class Preferences(context: Context)
 			.coerceIn(RUMBLE_INTENSITY_MIN, RUMBLE_INTENSITY_MAX)
 		set(value) { sharedPreferences.edit().putInt(rumbleIntensityKey, value.coerceIn(RUMBLE_INTENSITY_MIN, RUMBLE_INTENSITY_MAX)).apply() }
 
-	val motionEnabledKey get() = resources.getString(R.string.preferences_motion_enabled_key)
-	var motionEnabled
-		get() = sharedPreferences.getBoolean(motionEnabledKey, true)
-		set(value) { sharedPreferences.edit().putBoolean(motionEnabledKey, value).apply() }
+	/** Where the motion data (gyro/accel/orientation) streamed to the console comes
+	 * from. Matches iOS' MotionSource setting. */
+	enum class MotionSource(val value: String)
+	{
+		AUTO("auto"),        // controller when it has sensors (Android 12+), else this device
+		CONTROLLER("controller"),
+		PHONE("phone"),
+		OFF("off");
+
+		companion object
+		{
+			fun fromValue(value: String?) = values().firstOrNull { it.value == value }
+		}
+	}
+
+	private val motionEnabledLegacyKey get() = resources.getString(R.string.preferences_motion_enabled_key)
+	val motionSourceKey get() = resources.getString(R.string.preferences_motion_source_key)
+	var motionSource: MotionSource
+		get()
+		{
+			MotionSource.fromValue(sharedPreferences.getString(motionSourceKey, null))?.let { return it }
+			// Migrate the legacy Motion bool (Off stays off; anything else = Auto).
+			val legacy = sharedPreferences.getBoolean(motionEnabledLegacyKey, true)
+			return if(legacy) MotionSource.AUTO else MotionSource.OFF
+		}
+		set(value) { sharedPreferences.edit().putString(motionSourceKey, value.value).apply() }
 
 	val buttonHapticEnabledKey get() = resources.getString(R.string.preferences_button_haptic_enabled_key)
 	var buttonHapticEnabled

--- a/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
@@ -153,6 +153,14 @@ private class ChiakiNative
 		@JvmStatic external fun sessionSetControllerState(ptr: Long, controllerState: ControllerState)
 		@JvmStatic external fun sessionSetPsChord(ptr: Long, enabled: Boolean, holdMs: Int)
 		@JvmStatic external fun sessionSetLoginPin(ptr: Long, pin: String)
+		// Shared Madgwick orientation tracker (lib/src/orientation.c) for the
+		// controller-motion path: controller sensors provide only gyro/accel.
+		// update() fills out[10]: gyro xyz, accel xyz, orientation quat xyzw.
+		@JvmStatic external fun orientationTrackerCreate(): Long
+		@JvmStatic external fun orientationTrackerFree(ptr: Long)
+		@JvmStatic external fun orientationTrackerUpdate(ptr: Long,
+			gx: Float, gy: Float, gz: Float, ax: Float, ay: Float, az: Float,
+			timestampUs: Long, out: FloatArray)
 		@JvmStatic external fun discoveryServiceCreate(result: CreateResult, options: DiscoveryServiceOptions, javaService: DiscoveryService)
 		@JvmStatic external fun discoveryServiceFree(ptr: Long)
 		@JvmStatic external fun discoveryServiceWakeup(ptr: Long, host: String, userCredential: Long, ps5: Boolean)
@@ -398,6 +406,37 @@ class ErrorCode(val value: Int)
 {
 	override fun toString() = ChiakiNative.errorCodeToString(value)
 	var isSuccess = value == 0
+}
+
+/**
+ * Shared Madgwick orientation tracker (lib/src/orientation.c), used by the
+ * controller-motion path: controller sensors (InputDevice.getSensorManager)
+ * expose only gyro/accel — no rotation vector — so orientation is computed with
+ * the same algorithm Qt (SDL) and iOS (GCMotion) use.
+ */
+class OrientationTracker
+{
+	private var ptr = ChiakiNative.orientationTrackerCreate()
+
+	/**
+	 * Feed one gyro (rad/s) + accel (G) sample. Fills out[10] with the tracked
+	 * state: gyro xyz, accel xyz, orientation quaternion xyzw.
+	 */
+	fun update(gx: Float, gy: Float, gz: Float, ax: Float, ay: Float, az: Float, timestampUs: Long, out: FloatArray)
+	{
+		val p = ptr
+		if(p != 0L)
+			ChiakiNative.orientationTrackerUpdate(p, gx, gy, gz, ax, ay, az, timestampUs, out)
+	}
+
+	fun dispose()
+	{
+		if(ptr != 0L)
+		{
+			ChiakiNative.orientationTrackerFree(ptr)
+			ptr = 0L
+		}
+	}
 }
 
 class ChiakiLog(val levelMask: Int, val callback: (level: Int, text: String) -> Unit)

--- a/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
@@ -151,6 +151,7 @@ private class ChiakiNative
 		@JvmStatic external fun sessionSetSurface(ptr: Long, surface: Surface?)
 		@JvmStatic external fun sessionGetMetrics(ptr: Long): DoubleArray
 		@JvmStatic external fun sessionSetControllerState(ptr: Long, controllerState: ControllerState)
+		@JvmStatic external fun sessionSetPsChord(ptr: Long, enabled: Boolean, holdMs: Int)
 		@JvmStatic external fun sessionSetLoginPin(ptr: Long, pin: String)
 		@JvmStatic external fun discoveryServiceCreate(result: CreateResult, options: DiscoveryServiceOptions, javaService: DiscoveryService)
 		@JvmStatic external fun discoveryServiceFree(ptr: Long)
@@ -692,6 +693,11 @@ class Session(connectInfo: ConnectInfo, logFile: String?, logVerbose: Boolean)
 	fun setControllerState(controllerState: ControllerState)
 	{
 		ChiakiNative.sessionSetControllerState(nativePtr, controllerState)
+	}
+
+	fun setPsChord(enabled: Boolean, holdMs: Int = 0)
+	{
+		ChiakiNative.sessionSetPsChord(nativePtr, enabled, holdMs)
 	}
 
 	fun setLoginPin(pin: String)

--- a/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/lib/Chiaki.kt
@@ -611,6 +611,7 @@ data class QuitEvent(val reason: QuitReason, val reasonString: String?): Event()
 data class RumbleEvent(val left: UByte, val right: UByte): Event()
 data class AutoRegistEvent(val host: RegistHost): Event()
 object HolepunchEvent: Event()
+object PsChordEvent: Event() // OPTIONS+SHARE chord fired -> surface the in-stream menu
 
 class CreateError(val errorCode: ErrorCode): Exception("Failed to create a native object: $errorCode")
 
@@ -679,6 +680,12 @@ class Session(connectInfo: ConnectInfo, logFile: String?, logVerbose: Boolean)
 	private fun eventHolepunch()
 	{
 		event(HolepunchEvent)
+	}
+
+	// Called from native (chiaki-jni.c) when the OPTIONS+SHARE chord fires.
+	private fun eventPsChord()
+	{
+		event(PsChordEvent)
 	}
 
 	fun setSurface(surface: Surface?)

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
@@ -49,7 +49,7 @@ class StreamInput(val context: Context, val preferences: Preferences)
 			controllerState = controllerState or dpadTouchControllerState
 		}
 
-		return controllerState or touchControllerState
+		return controllerState or touchControllerState or capturedTouchpadControllerState
 	}
 
 	private val sensorControllerState = ControllerState() // from Motion Sensors
@@ -62,6 +62,10 @@ class StreamInput(val context: Context, val preferences: Preferences)
 			field = value
 			controllerStateUpdated()
 		}
+	// Physical controller touchpad (DualSense/DS4) delivered via pointer capture
+	// (StreamActivity requests capture on the stream view, API 26+).
+	private val capturedTouchpadControllerState = ControllerState()
+	private val capturedTouchIds = mutableMapOf<Int, UByte>() // MotionEvent pointerId -> chiaki touch id
 
 	private val swapCrossMoon = preferences.swapCrossMoon
 	private val mapSelectToTouchpad = preferences.mapSelectToTouchpad
@@ -110,6 +114,105 @@ class StreamInput(val context: Context, val preferences: Preferences)
 	{
 		cancelDpadTouchTimers()
 		stopDpadTouch()
+		releaseCapturedTouchpad()
+	}
+
+	/**
+	 * Drop all captured-touchpad state (touches + click). Called when pointer
+	 * capture is lost/released so no finger stays "stuck" on the virtual pad.
+	 */
+	fun releaseCapturedTouchpad()
+	{
+		var changed = capturedTouchIds.isNotEmpty()
+			|| capturedTouchpadControllerState.buttons and ControllerState.BUTTON_TOUCHPAD != 0U
+		capturedTouchIds.values.forEach { capturedTouchpadControllerState.stopTouch(it) }
+		capturedTouchIds.clear()
+		capturedTouchpadControllerState.buttons =
+			capturedTouchpadControllerState.buttons and ControllerState.BUTTON_TOUCHPAD.inv()
+		if(changed)
+			controllerStateUpdated()
+	}
+
+	/**
+	 * Events delivered while the stream view holds pointer capture. Under capture
+	 * a physical controller touchpad (DualSense/DS4) reports ABSOLUTE per-finger
+	 * positions with SOURCE_TOUCHPAD; positions are scaled to the PS touchpad
+	 * coordinate space. The pad's physical click arrives as BUTTON_PRIMARY (also
+	 * when the pad is presented as a mouse on some Android versions, which is why
+	 * the click is handled for every captured source).
+	 */
+	fun onCapturedPointerEvent(event: MotionEvent): Boolean
+	{
+		var changed = false
+
+		val clicked = event.buttonState and MotionEvent.BUTTON_PRIMARY != 0
+		val hadClick = capturedTouchpadControllerState.buttons and ControllerState.BUTTON_TOUCHPAD != 0U
+		if(clicked != hadClick)
+		{
+			capturedTouchpadControllerState.buttons =
+				if(clicked) capturedTouchpadControllerState.buttons or ControllerState.BUTTON_TOUCHPAD
+				else capturedTouchpadControllerState.buttons and ControllerState.BUTTON_TOUCHPAD.inv()
+			changed = true
+		}
+
+		if(event.source and InputDevice.SOURCE_TOUCHPAD == InputDevice.SOURCE_TOUCHPAD)
+		{
+			val xRange = event.device?.getMotionRange(MotionEvent.AXIS_X, event.source)
+			val yRange = event.device?.getMotionRange(MotionEvent.AXIS_Y, event.source)
+			fun scale(v: Float, min: Float, max: Float, target: UShort): UShort
+			{
+				val norm = if(max > min) ((v - min) / (max - min)).coerceIn(0f, 1f) else 0f
+				return (norm * (target.toInt() - 1).toFloat()).toInt().toUShort()
+			}
+			fun scaledX(i: Int) = scale(event.getX(i), xRange?.min ?: 0f, xRange?.max ?: 1f, ControllerState.TOUCHPAD_WIDTH)
+			fun scaledY(i: Int) = scale(event.getY(i), yRange?.min ?: 0f, yRange?.max ?: 1f, ControllerState.TOUCHPAD_HEIGHT)
+
+			when(event.actionMasked)
+			{
+				MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN ->
+				{
+					val idx = event.actionIndex
+					val pid = event.getPointerId(idx)
+					// If this pointer id is somehow already mapped (e.g. a missed UP
+					// after a capture blip), release the stale chiaki touch first so
+					// we don't leak a touch slot / leave a finger stuck.
+					capturedTouchIds.remove(pid)?.let {
+						capturedTouchpadControllerState.stopTouch(it)
+						changed = true
+					}
+					capturedTouchpadControllerState.startTouch(scaledX(idx), scaledY(idx))?.let {
+						capturedTouchIds[pid] = it
+						changed = true
+					}
+				}
+				MotionEvent.ACTION_MOVE ->
+					for(i in 0 until event.pointerCount)
+						capturedTouchIds[event.getPointerId(i)]?.let {
+							if(capturedTouchpadControllerState.setTouchPos(it, scaledX(i), scaledY(i)))
+								changed = true
+						}
+				MotionEvent.ACTION_UP, MotionEvent.ACTION_POINTER_UP ->
+				{
+					capturedTouchIds.remove(event.getPointerId(event.actionIndex))?.let {
+						capturedTouchpadControllerState.stopTouch(it)
+						changed = true
+					}
+				}
+				MotionEvent.ACTION_CANCEL ->
+				{
+					if(capturedTouchIds.isNotEmpty())
+					{
+						capturedTouchIds.values.forEach { capturedTouchpadControllerState.stopTouch(it) }
+						capturedTouchIds.clear()
+						changed = true
+					}
+				}
+			}
+		}
+
+		if(changed)
+			controllerStateUpdated()
+		return true
 	}
 
 	private val sensorEventListener = object: SensorEventListener {

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
 import com.metallic.chiaki.common.Preferences
 import com.metallic.chiaki.lib.ControllerState
+import com.metallic.chiaki.lib.OrientationTracker
 
 class StreamInput(val context: Context, val preferences: Preferences)
 {
@@ -20,19 +21,25 @@ class StreamInput(val context: Context, val preferences: Preferences)
 	{
 		var controllerState = sensorControllerState or keyControllerState or motionControllerState
 
-		val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-		@Suppress("DEPRECATION")
-		when(windowManager.defaultDisplay.rotation)
+		// Screen-rotation correction applies only to PHONE motion (the sensor frame
+		// is fixed to the device's portrait orientation); a controller's sensors are
+		// in the controller's own frame, independent of the display.
+		if(!controllerMotionActive)
 		{
-			Surface.ROTATION_90 -> {
-				controllerState.accelX *= -1.0f
-				controllerState.accelZ *= -1.0f
-				controllerState.gyroX *= -1.0f
-				controllerState.gyroZ *= -1.0f
-				controllerState.orientX *= -1.0f
-				controllerState.orientZ *= -1.0f
+			val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+			@Suppress("DEPRECATION")
+			when(windowManager.defaultDisplay.rotation)
+			{
+				Surface.ROTATION_90 -> {
+					controllerState.accelX *= -1.0f
+					controllerState.accelZ *= -1.0f
+					controllerState.gyroX *= -1.0f
+					controllerState.gyroZ *= -1.0f
+					controllerState.orientX *= -1.0f
+					controllerState.orientZ *= -1.0f
+				}
+				else -> {}
 			}
-			else -> {}
 		}
 
 		// prioritize motion controller's l2 and r2 over key
@@ -246,32 +253,206 @@ class StreamInput(val context: Context, val preferences: Preferences)
 		override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {}
 	}
 
+	// --- Controller motion (Android 12+: InputDevice.getSensorManager) ---
+	// DualSense/DS4 expose gyro+accel through the input device's own SensorManager.
+	// The sensors report in the controller's frame (x right, y up, z toward the
+	// player — the PS convention, same as SDL on desktop), so values map directly:
+	// no phone-style axis remap and no display-rotation correction. Orientation is
+	// computed by the shared C Madgwick tracker (input devices have no
+	// rotation-vector sensor).
+
+	/** True while motion comes from the controller — gates the display-rotation fix. */
+	private var controllerMotionActive = false
+	private var controllerSensorManager: SensorManager? = null
+	private var orientationTracker: OrientationTracker? = null
+	private val orientationTrackerOut = FloatArray(10)
+	private var controllerGyro = floatArrayOf(0f, 0f, 0f)
+	private var controllerAccel = floatArrayOf(0f, 1f, 0f)
+
+	private val controllerSensorEventListener = object: SensorEventListener {
+		override fun onSensorChanged(event: SensorEvent)
+		{
+			when(event.sensor.type)
+			{
+				Sensor.TYPE_ACCELEROMETER -> {
+					controllerAccel[0] = event.values[0] / SensorManager.GRAVITY_EARTH
+					controllerAccel[1] = event.values[1] / SensorManager.GRAVITY_EARTH
+					controllerAccel[2] = event.values[2] / SensorManager.GRAVITY_EARTH
+				}
+				Sensor.TYPE_GYROSCOPE -> {
+					controllerGyro[0] = event.values[0]
+					controllerGyro[1] = event.values[1]
+					controllerGyro[2] = event.values[2]
+				}
+				else -> return
+			}
+			val tracker = orientationTracker ?: return
+			tracker.update(
+				controllerGyro[0], controllerGyro[1], controllerGyro[2],
+				controllerAccel[0], controllerAccel[1], controllerAccel[2],
+				event.timestamp / 1000, orientationTrackerOut)
+			sensorControllerState.gyroX = orientationTrackerOut[0]
+			sensorControllerState.gyroY = orientationTrackerOut[1]
+			sensorControllerState.gyroZ = orientationTrackerOut[2]
+			sensorControllerState.accelX = orientationTrackerOut[3]
+			sensorControllerState.accelY = orientationTrackerOut[4]
+			sensorControllerState.accelZ = orientationTrackerOut[5]
+			sensorControllerState.orientX = orientationTrackerOut[6]
+			sensorControllerState.orientY = orientationTrackerOut[7]
+			sensorControllerState.orientZ = orientationTrackerOut[8]
+			sensorControllerState.orientW = orientationTrackerOut[9]
+			controllerStateUpdated()
+		}
+
+		override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {}
+	}
+
+	/** Device id + SensorManager of the first attached gamepad that exposes a gyroscope, or null. */
+	private fun controllerMotionDeviceOrNull(): Pair<Int, SensorManager>?
+	{
+		if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S)
+			return null
+		val inputManager = context.getSystemService(Context.INPUT_SERVICE) as android.hardware.input.InputManager
+		for(deviceId in inputManager.inputDeviceIds)
+		{
+			val device = inputManager.getInputDevice(deviceId) ?: continue
+			if(device.isVirtual)
+				continue
+			val isGamepad = (device.sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD)
+				|| (device.sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK)
+			if(!isGamepad)
+				continue
+			val sensorManager = device.sensorManager
+			if(sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE) != null)
+				return Pair(deviceId, sensorManager)
+		}
+		return null
+	}
+
+	private fun resetMotionState()
+	{
+		sensorControllerState.gyroX = 0f
+		sensorControllerState.gyroY = 0f
+		sensorControllerState.gyroZ = 0f
+		sensorControllerState.accelX = 0f
+		sensorControllerState.accelY = 1f
+		sensorControllerState.accelZ = 0f
+		sensorControllerState.orientX = 0f
+		sensorControllerState.orientY = 0f
+		sensorControllerState.orientZ = 0f
+		sensorControllerState.orientW = 1f
+	}
+
+	/** (Re)register the motion source per the MotionSource preference and what is
+	 * attached. Called on resume and when a controller connects/disconnects. */
+	private var phoneMotionActive = false
+	private var controllerMotionDeviceId = -1
+
+	private fun registerMotionSensors()
+	{
+		val samplingPeriodUs = 4000
+		val source = preferences.motionSource
+		val controllerDevice = when(source)
+		{
+			Preferences.MotionSource.AUTO, Preferences.MotionSource.CONTROLLER -> controllerMotionDeviceOrNull()
+			else -> null
+		}
+		val wantPhone = source == Preferences.MotionSource.PHONE
+			|| (source == Preferences.MotionSource.AUTO && controllerDevice == null)
+
+		// Idempotent: connect/disconnect events arrive in bursts (a Bluetooth
+		// reconnect fires added + several changed); don't churn listeners when
+		// nothing resolved differently.
+		if(controllerDevice != null && controllerMotionActive && controllerMotionDeviceId == controllerDevice.first)
+			return
+		if(controllerDevice == null && wantPhone && phoneMotionActive)
+			return
+
+		unregisterMotionSensors()
+		if(controllerDevice != null)
+		{
+			val (deviceId, sensorManager) = controllerDevice
+			if(orientationTracker == null)
+				orientationTracker = OrientationTracker()
+			listOfNotNull(
+				sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
+				sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+			).forEach {
+				sensorManager.registerListener(controllerSensorEventListener, it, samplingPeriodUs)
+			}
+			controllerSensorManager = sensorManager
+			controllerMotionDeviceId = deviceId
+			controllerMotionActive = true
+			return
+		}
+		if(!wantPhone)
+			return // OFF, or controller-only with no controller sensors
+		val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+		listOfNotNull(
+			sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
+			sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE),
+			sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+		).forEach {
+			sensorManager.registerListener(sensorEventListener, it, samplingPeriodUs)
+		}
+		phoneMotionActive = true
+	}
+
+	private fun unregisterMotionSensors()
+	{
+		val phoneSensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+		phoneSensorManager.unregisterListener(sensorEventListener)
+		controllerSensorManager?.unregisterListener(controllerSensorEventListener)
+		controllerSensorManager = null
+		controllerMotionActive = false
+		controllerMotionDeviceId = -1
+		phoneMotionActive = false
+		resetMotionState()
+	}
+
+	private val motionReevaluateRunnable = Runnable { registerMotionSensors() }
+
+	private val inputDeviceListener = object: android.hardware.input.InputManager.InputDeviceListener {
+		// A Bluetooth controller is often announced before its sensors are
+		// queryable; the sensors appear in a later "changed" event. React to all
+		// three, plus a delayed re-check as insurance, so AUTO reliably switches
+		// back to the controller after a reconnect.
+		override fun onInputDeviceAdded(deviceId: Int)
+		{
+			registerMotionSensors()
+			handler.removeCallbacks(motionReevaluateRunnable)
+			handler.postDelayed(motionReevaluateRunnable, 1000)
+		}
+		override fun onInputDeviceRemoved(deviceId: Int) { registerMotionSensors() }
+		override fun onInputDeviceChanged(deviceId: Int) { registerMotionSensors() }
+	}
+
 	private val motionLifecycleObserver = object: LifecycleObserver {
 		@OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
 		fun onResume()
 		{
-			val samplingPeriodUs = 4000
-			val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-			listOfNotNull(
-				sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
-				sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE),
-				sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
-			).forEach {
-				sensorManager.registerListener(sensorEventListener, it, samplingPeriodUs)
-			}
+			registerMotionSensors()
+			// Re-evaluate the source when a controller connects or disconnects
+			// (AUTO falls back to the phone and returns to the controller).
+			val inputManager = context.getSystemService(Context.INPUT_SERVICE) as android.hardware.input.InputManager
+			inputManager.registerInputDeviceListener(inputDeviceListener, Handler(Looper.getMainLooper()))
 		}
 
 		@OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
 		fun onPause()
 		{
-			val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-			sensorManager.unregisterListener(sensorEventListener)
+			val inputManager = context.getSystemService(Context.INPUT_SERVICE) as android.hardware.input.InputManager
+			inputManager.unregisterInputDeviceListener(inputDeviceListener)
+			handler.removeCallbacks(motionReevaluateRunnable)
+			unregisterMotionSensors()
+			orientationTracker?.dispose()
+			orientationTracker = null
 		}
 	}
 
 	fun observe(lifecycleOwner: LifecycleOwner)
 	{
-		if(preferences.motionEnabled)
+		if(preferences.motionSource != Preferences.MotionSource.OFF)
 			lifecycleOwner.lifecycle.addObserver(motionLifecycleObserver)
 	}
 

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
@@ -408,6 +408,9 @@ class StreamInput(val context: Context, val preferences: Preferences)
 		controllerMotionDeviceId = -1
 		phoneMotionActive = false
 		resetMotionState()
+		// Send the idle motion once -- without this the console keeps acting on the
+		// last gyro/orientation values until the next unrelated input event.
+		controllerStateUpdated()
 	}
 
 	private val motionReevaluateRunnable = Runnable { registerMotionSensors() }

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
@@ -400,6 +400,7 @@ class StreamInput(val context: Context, val preferences: Preferences)
 
 	private fun unregisterMotionSensors()
 	{
+		val wasActive = controllerMotionActive || phoneMotionActive
 		val phoneSensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
 		phoneSensorManager.unregisterListener(sensorEventListener)
 		controllerSensorManager?.unregisterListener(controllerSensorEventListener)
@@ -407,6 +408,8 @@ class StreamInput(val context: Context, val preferences: Preferences)
 		controllerMotionActive = false
 		controllerMotionDeviceId = -1
 		phoneMotionActive = false
+		if(!wasActive)
+			return // nothing was feeding motion, so there's no stale state to clear
 		resetMotionState()
 		// Send the idle motion once -- without this the console keeps acting on the
 		// last gyro/orientation values until the next unrelated input event.

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamInput.kt
@@ -23,8 +23,10 @@ class StreamInput(val context: Context, val preferences: Preferences)
 
 		// Screen-rotation correction applies only to PHONE motion (the sensor frame
 		// is fixed to the device's portrait orientation); a controller's sensors are
-		// in the controller's own frame, independent of the display.
-		if(!controllerMotionActive)
+		// in the controller's own frame, independent of the display. Gate on the
+		// data's ORIGIN: right after a controller disconnect the held pose is still
+		// controller-frame data and must not be flipped.
+		if(!sensorStateFromController)
 		{
 			val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
 			@Suppress("DEPRECATION")
@@ -247,6 +249,7 @@ class StreamInput(val context: Context, val preferences: Preferences)
 				}
 				else -> return
 			}
+			sensorStateFromController = false
 			controllerStateUpdated()
 		}
 
@@ -263,26 +266,87 @@ class StreamInput(val context: Context, val preferences: Preferences)
 
 	/** True while motion comes from the controller — gates the display-rotation fix. */
 	private var controllerMotionActive = false
+	/** Which source last WROTE sensorControllerState. The display-rotation flip
+	 * must track the data's origin, not the currently-active listener: after a
+	 * controller disconnect the frozen pose is still controller-frame data, and
+	 * flipping it (as happens the moment controllerMotionActive goes false)
+	 * visibly mirrors the held orientation. */
+	private var sensorStateFromController = false
 	private var controllerSensorManager: SensorManager? = null
 	private var orientationTracker: OrientationTracker? = null
 	private val orientationTrackerOut = FloatArray(10)
 	private var controllerGyro = floatArrayOf(0f, 0f, 0f)
 	private var controllerAccel = floatArrayOf(0f, 1f, 0f)
 
+	/** False from (re)registration until the first accel sample of the NEW
+	 * connection arrives. The tracker must not warm up on the cached accel of a
+	 * dying connection -- warmup converges hard toward whatever gravity it sees
+	 * first, and recovering from a wrong warmup takes tens of seconds. */
+	private var controllerAccelFresh = false
+	/** Discard controller sensor events stamped before this (elapsedRealtimeNanos,
+	 * same base as SensorEvent.timestamp). Re-registering after a reconnect can
+	 * flush the sensor FIFO's queued pre-disconnect samples -- including the
+	 * unplug jostle -- and warming the tracker up on those skews it for tens of
+	 * seconds. The extra settle margin also skips the re-plug handling wobble. */
+	private var controllerMotionAcceptFromNs = 0L
+	/** The tracker's high-gain warmup only runs for its first 30 samples; any
+	 * attitude error it locks in heals at ~1 deg/s afterwards. So don't start
+	 * feeding until the pad is QUIET (verified empirically: warming up while the
+	 * hand is still seating the plug landed 20+ deg off and crawled back for
+	 * 15s). Capped so motion still comes up promptly if the pad never rests. */
+	private var controllerTrackerFeeding = false
+	private var controllerQuietSinceNs = 0L
+	/** Samples fed since the fresh tracker started. The tracker holds identity
+	 * through its 30-sample warmup; keep reporting the LAST pose until warmup
+	 * completes so a reconnect goes frozen-pose -> live truth with no neutral
+	 * flash in between. */
+	private var controllerTrackerFedSamples = 0
 	private val controllerSensorEventListener = object: SensorEventListener {
 		override fun onSensorChanged(event: SensorEvent)
 		{
+			if(event.timestamp < controllerMotionAcceptFromNs)
+				return // stale FIFO backlog or settle window -- not live attitude
 			when(event.sensor.type)
 			{
 				Sensor.TYPE_ACCELEROMETER -> {
+					// Cache only -- the tracker is updated once per GYRO event so its
+					// update cadence is well-defined (see trackerPeriodUs below).
+					// NOTE: the reported gravity vector is only consistent WITHIN a
+					// connection. The kernel driver loads the pad's IMU calibration at
+					// connect and quick reconnects can leave a connection uncalibrated
+					// (measured: same resting pose read 0.89g-1.13g with direction up
+					// to 16 deg apart across replugs). Absolute pose therefore steps a
+					// little on reconnect; that variance is device-side, don't chase
+					// it in this pipeline.
 					controllerAccel[0] = event.values[0] / SensorManager.GRAVITY_EARTH
 					controllerAccel[1] = event.values[1] / SensorManager.GRAVITY_EARTH
 					controllerAccel[2] = event.values[2] / SensorManager.GRAVITY_EARTH
+					controllerAccelFresh = true
+					return
 				}
 				Sensor.TYPE_GYROSCOPE -> {
 					controllerGyro[0] = event.values[0]
 					controllerGyro[1] = event.values[1]
 					controllerGyro[2] = event.values[2]
+					if(!controllerAccelFresh)
+						return // no live accel yet -- don't warm the tracker up on stale gravity
+					if(!controllerTrackerFeeding)
+					{
+						val rate = Math.sqrt((controllerGyro[0] * controllerGyro[0]
+							+ controllerGyro[1] * controllerGyro[1]
+							+ controllerGyro[2] * controllerGyro[2]).toDouble())
+						if(rate > 0.25)
+							controllerQuietSinceNs = 0L
+						else if(controllerQuietSinceNs == 0L)
+							controllerQuietSinceNs = event.timestamp
+						val quiet = controllerQuietSinceNs != 0L
+							&& event.timestamp - controllerQuietSinceNs >= 250_000_000L
+						val waitedLongEnough =
+							event.timestamp >= controllerMotionAcceptFromNs + 1_500_000_000L
+						if(!quiet && !waitedLongEnough)
+							return
+						controllerTrackerFeeding = true
+					}
 				}
 				else -> return
 			}
@@ -291,16 +355,21 @@ class StreamInput(val context: Context, val preferences: Preferences)
 				controllerGyro[0], controllerGyro[1], controllerGyro[2],
 				controllerAccel[0], controllerAccel[1], controllerAccel[2],
 				event.timestamp / 1000, orientationTrackerOut)
+			controllerTrackerFedSamples++
 			sensorControllerState.gyroX = orientationTrackerOut[0]
 			sensorControllerState.gyroY = orientationTrackerOut[1]
 			sensorControllerState.gyroZ = orientationTrackerOut[2]
 			sensorControllerState.accelX = orientationTrackerOut[3]
 			sensorControllerState.accelY = orientationTrackerOut[4]
 			sensorControllerState.accelZ = orientationTrackerOut[5]
-			sensorControllerState.orientX = orientationTrackerOut[6]
-			sensorControllerState.orientY = orientationTrackerOut[7]
-			sensorControllerState.orientZ = orientationTrackerOut[8]
-			sensorControllerState.orientW = orientationTrackerOut[9]
+			if(controllerTrackerFedSamples > 32) // tracker warmup (30 samples) + margin
+			{
+				sensorControllerState.orientX = orientationTrackerOut[6]
+				sensorControllerState.orientY = orientationTrackerOut[7]
+				sensorControllerState.orientZ = orientationTrackerOut[8]
+				sensorControllerState.orientW = orientationTrackerOut[9]
+			}
+			sensorStateFromController = true
 			controllerStateUpdated()
 		}
 
@@ -329,18 +398,16 @@ class StreamInput(val context: Context, val preferences: Preferences)
 		return null
 	}
 
-	private fun resetMotionState()
+	/** Zero only the ROTATION RATES. Orientation and accel deliberately keep
+	 * their last values: on disconnect the pad hasn't physically moved, so
+	 * resetting the pose to identity makes the console visibly snap away from
+	 * the true attitude. Stale rates are the harmful part -- the console keeps
+	 * rotating on them forever. */
+	private fun resetMotionRates()
 	{
 		sensorControllerState.gyroX = 0f
 		sensorControllerState.gyroY = 0f
 		sensorControllerState.gyroZ = 0f
-		sensorControllerState.accelX = 0f
-		sensorControllerState.accelY = 1f
-		sensorControllerState.accelZ = 0f
-		sensorControllerState.orientX = 0f
-		sensorControllerState.orientY = 0f
-		sensorControllerState.orientZ = 0f
-		sensorControllerState.orientW = 1f
 	}
 
 	/** (Re)register the motion source per the MotionSource preference and what is
@@ -372,13 +439,31 @@ class StreamInput(val context: Context, val preferences: Preferences)
 		if(controllerDevice != null)
 		{
 			val (deviceId, sensorManager) = controllerDevice
-			if(orientationTracker == null)
-				orientationTracker = OrientationTracker()
+			// Fresh tracker on every (re)registration: after a reconnect the old
+			// filter state is stale, the timestamp gap would integrate as one huge
+			// step, and the high-beta warmup only runs for a tracker's first 30
+			// samples -- post-warmup convergence is far too slow to recover from
+			// either. Costs a yaw re-zero to the current heading, same as a fresh
+			// stream (pitch/roll re-converge from gravity during warmup, ~0.5s).
+			orientationTracker?.dispose()
+			orientationTracker = OrientationTracker()
+			controllerAccelFresh = false
+			controllerMotionAcceptFromNs = android.os.SystemClock.elapsedRealtimeNanos() + 500_000_000L
+			controllerTrackerFeeding = false
+			controllerQuietSinceNs = 0L
+			controllerTrackerFedSamples = 0
+			// 60Hz, NOT samplingPeriodUs: the shared tracker's output deadband
+			// (ORIENT_FUZZ in lib/src/orientation.c) swallows per-update corrections
+			// of beta*dt when dt is small -- at 250Hz the filter freezes right after
+			// warmup and the orientation latches wherever the first ~100ms left it.
+			// 60Hz matches the cadence iOS feeds the same tracker at.
+			val trackerPeriodUs = 16666
 			listOfNotNull(
 				sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER),
 				sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
 			).forEach {
-				sensorManager.registerListener(controllerSensorEventListener, it, samplingPeriodUs)
+				// maxReportLatencyUs=0: real-time delivery, no FIFO batching.
+				sensorManager.registerListener(controllerSensorEventListener, it, trackerPeriodUs, 0)
 			}
 			controllerSensorManager = sensorManager
 			controllerMotionDeviceId = deviceId
@@ -410,9 +495,9 @@ class StreamInput(val context: Context, val preferences: Preferences)
 		phoneMotionActive = false
 		if(!wasActive)
 			return // nothing was feeding motion, so there's no stale state to clear
-		resetMotionState()
-		// Send the idle motion once -- without this the console keeps acting on the
-		// last gyro/orientation values until the next unrelated input event.
+		resetMotionRates()
+		// Send the stilled rates once -- without this the console keeps rotating on
+		// the last gyro values until the next unrelated input event.
 		controllerStateUpdated()
 	}
 
@@ -423,14 +508,22 @@ class StreamInput(val context: Context, val preferences: Preferences)
 		// queryable; the sensors appear in a later "changed" event. React to all
 		// three, plus a delayed re-check as insurance, so AUTO reliably switches
 		// back to the controller after a reconnect.
-		override fun onInputDeviceAdded(deviceId: Int)
+		//
+		// NEVER call registerMotionSensors() synchronously from these callbacks:
+		// InputDeviceSensorManager.registerListener and the framework's
+		// device-changed binder delivery take the same two locks in opposite
+		// order (observed AB-BA deadlock -> input-dispatch ANR). Deferring via
+		// the handler runs registration after the event storm drains, and also
+		// coalesces a reconnect's added+changed burst into one registration.
+		private fun scheduleReevaluate()
 		{
-			registerMotionSensors()
 			handler.removeCallbacks(motionReevaluateRunnable)
-			handler.postDelayed(motionReevaluateRunnable, 1000)
+			handler.postDelayed(motionReevaluateRunnable, 250)
+			handler.postDelayed(motionReevaluateRunnable, 1200) // sensors-appear-late insurance
 		}
-		override fun onInputDeviceRemoved(deviceId: Int) { registerMotionSensors() }
-		override fun onInputDeviceChanged(deviceId: Int) { registerMotionSensors() }
+		override fun onInputDeviceAdded(deviceId: Int) { scheduleReevaluate() }
+		override fun onInputDeviceRemoved(deviceId: Int) { scheduleReevaluate() }
+		override fun onInputDeviceChanged(deviceId: Int) { scheduleReevaluate() }
 	}
 
 	private val motionLifecycleObserver = object: LifecycleObserver {

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamSession.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamSession.kt
@@ -27,6 +27,9 @@ class StreamSession(val connectInfo: ConnectInfo, val logManager: LogManager, va
 	val state: LiveData<StreamState> get() = _state
 	private val _rumbleState = MutableLiveData<RumbleEvent>(RumbleEvent(0U, 0U))
 	val rumbleState: LiveData<RumbleEvent> get() = _rumbleState
+	// Bumped each time the OPTIONS+SHARE chord fires, so the activity surfaces the in-stream menu.
+	private val _menuRequest = MutableLiveData(0)
+	val menuRequest: LiveData<Int> get() = _menuRequest
 
 	private var surfaceTexture: SurfaceTexture? = null
 	private var surface: Surface? = null
@@ -264,6 +267,10 @@ class StreamSession(val connectInfo: ConnectInfo, val logManager: LogManager, va
 			is RumbleEvent -> _rumbleState.postValue(event)
 			is AutoRegistEvent -> Log.i("StreamSession", "EVENT: AutoRegist host=${event.host.serverNickname}")
 			is HolepunchEvent -> Log.i("StreamSession", "EVENT: Holepunch")
+			is PsChordEvent -> {
+				Log.i("StreamSession", "EVENT: PsChord -> requesting in-stream menu")
+				_menuRequest.postValue((_menuRequest.value ?: 0) + 1)
+			}
 		}
 	}
 

--- a/android/app/src/main/java/com/metallic/chiaki/session/StreamSession.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/session/StreamSession.kt
@@ -185,6 +185,7 @@ class StreamSession(val connectInfo: ConnectInfo, val logManager: LogManager, va
 				val psnConnectInfo = connectInfo.copy(holepunchSessionPtr = hpSession.getPtr())
 				val session = Session(psnConnectInfo, logManager.createNewFile().file.absolutePath, logVerbose)
 				session.eventCallback = this::eventCallback
+				session.setPsChord(true) // always on: safe, no user toggle
 				session.start()
 				val surface = surface
 				if(surface != null)
@@ -218,6 +219,7 @@ class StreamSession(val connectInfo: ConnectInfo, val logManager: LogManager, va
 			{
 				val session = Session(connectInfo, logManager.createNewFile().file.absolutePath, logVerbose)
 				session.eventCallback = this::eventCallback
+				session.setPsChord(true) // always on: safe, no user toggle
 				session.start()
 				val surface = surface
 				if(surface != null)

--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
@@ -40,7 +40,6 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 		preferences.mapSelectToTouchpadKey -> preferences.mapSelectToTouchpad
 		preferences.dpadTouchEnabledKey -> preferences.dpadTouchEnabled
 		preferences.rumbleEnabledKey -> preferences.rumbleEnabled
-		preferences.motionEnabledKey -> preferences.motionEnabled
 		preferences.buttonHapticEnabledKey -> preferences.buttonHapticEnabled
 		else -> defValue
 	}
@@ -54,13 +53,13 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 			preferences.mapSelectToTouchpadKey -> preferences.mapSelectToTouchpad = value
 			preferences.dpadTouchEnabledKey -> preferences.dpadTouchEnabled = value
 			preferences.rumbleEnabledKey -> preferences.rumbleEnabled = value
-			preferences.motionEnabledKey -> preferences.motionEnabled = value
 			preferences.buttonHapticEnabledKey -> preferences.buttonHapticEnabled = value
 		}
 	}
 
 	override fun getString(key: String, defValue: String?) = when(key)
 	{
+		preferences.motionSourceKey -> preferences.motionSource.value
 		preferences.resolutionKey -> preferences.resolution.value
 		preferences.fpsKey -> preferences.fps.value
 		preferences.bitrateKey -> preferences.bitrate?.toString() ?: ""
@@ -81,6 +80,11 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 	{
 		when(key)
 		{
+			preferences.motionSourceKey ->
+			{
+				val source = Preferences.MotionSource.fromValue(value) ?: return
+				preferences.motionSource = source
+			}
 			preferences.resolutionKey ->
 			{
 				val resolution = Preferences.Resolution.values().firstOrNull { it.value == value } ?: return

--- a/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/settings/SettingsFragment.kt
@@ -117,6 +117,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 		preferences.cloudBitratePscloudKey -> preferences.getCloudBitratePscloud() / 1000
 		preferences.cloudBitratePsnowKey -> preferences.getCloudBitratePsnow() / 1000
 		preferences.dpadTouchIncrementKey -> preferences.dpadTouchIncrement
+		preferences.rumbleIntensityKey -> preferences.rumbleIntensity
 		else -> defValue
 	}
 
@@ -127,6 +128,7 @@ class DataStore(val preferences: Preferences): PreferenceDataStore()
 			preferences.cloudBitratePscloudKey -> preferences.setCloudBitratePscloud(value * 1000)
 			preferences.cloudBitratePsnowKey -> preferences.setCloudBitratePsnow(value * 1000)
 			preferences.dpadTouchIncrementKey -> preferences.dpadTouchIncrement = value
+			preferences.rumbleIntensityKey -> preferences.rumbleIntensity = value
 		}
 	}
 

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -198,6 +198,7 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 			// User-scalable strength (0..500%). Read once at stream start (restart to change);
 			// avoids reading SharedPreferences on every rumble event (~80/s).
 			val rumbleScale = Preferences(this).rumbleIntensity / 100f
+			var lastVibrator: Vibrator? = null
 			viewModel.session.rumbleState.observe(this, Observer {
 				// Prefer the connected controller's own motor over the phone's
 				// (resolved per event so controller hotplug just works; the device
@@ -206,6 +207,12 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 				val cv = controllerVibrator()
 				val vibrator = cv ?: phoneVibrator
 				val amplitude = (((it.left.toInt() + it.right.toInt()) / 2) * rumbleScale).toInt().coerceIn(0, 255)
+				// Cancel the PREVIOUS target too: when the target switches
+				// (controller connects/disconnects mid-rumble), cancelling only the
+				// new one would leave the old motor buzzing out its 1s one-shot.
+				if(lastVibrator !== vibrator)
+					lastVibrator?.cancel()
+				lastVibrator = vibrator
 				vibrator.cancel()
 				if(amplitude == 0)
 					return@Observer

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -175,6 +175,16 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		//viewModel.session.attachToTextureView(textureView)
 		viewModel.session.attachToSurfaceView(binding.surfaceView)
 		viewModel.session.state.observe(this, Observer { this.stateChanged(it) })
+		// OPTIONS+SHARE chord fired -> surface the in-stream menu (parity with Qt/iOS).
+		// Seed from the current token so LiveData's replay on every (re)subscription --
+		// including each rotation/config-change, since the session lives in the ViewModel
+		// and survives -- does NOT re-show the overlay for an old chord. Only a strictly
+		// newer token opens the menu.
+		var lastMenuRequest = viewModel.session.menuRequest.value ?: 0
+		viewModel.session.menuRequest.observe(this, Observer {
+			if (it > lastMenuRequest) showOverlay()
+			lastMenuRequest = it
+		})
 		adjustStreamViewAspect()
 
 		if (isTv()) {
@@ -185,13 +195,17 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		if(Preferences(this).rumbleEnabled)
 		{
 			val phoneVibrator = getSystemService(VIBRATOR_SERVICE) as Vibrator
+			// User-scalable strength (0..500%). Read once at stream start (restart to change);
+			// avoids reading SharedPreferences on every rumble event (~80/s).
+			val rumbleScale = Preferences(this).rumbleIntensity / 100f
 			viewModel.session.rumbleState.observe(this, Observer {
 				// Prefer the connected controller's own motor over the phone's
 				// (resolved per event so controller hotplug just works; the device
 				// list is tiny and rumble events are sparse). L/R are averaged into
 				// one amplitude because both targets expose a single channel here.
-				val vibrator = controllerVibrator() ?: phoneVibrator
-				val amplitude = min(255, (it.left.toInt() + it.right.toInt()) / 2)
+				val cv = controllerVibrator()
+				val vibrator = cv ?: phoneVibrator
+				val amplitude = (((it.left.toInt() + it.right.toInt()) / 2) * rumbleScale).toInt().coerceIn(0, 255)
 				vibrator.cancel()
 				if(amplitude == 0)
 					return@Observer
@@ -554,6 +568,13 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		}
 		if(hasControllerTouchpad)
 		{
+			// Captured pointer events are delivered to the FOCUSED view. A SurfaceView is
+			// not focusable by default, so without this the window holds capture (dumpsys
+			// shows ABSOLUTE) yet onCapturedPointerEvent never fires and the touchpad keeps
+			// acting as a system mouse (the stray cursor). Make it focusable + take focus.
+			binding.surfaceView.isFocusableInTouchMode = true
+			binding.surfaceView.isFocusable = true
+			binding.surfaceView.requestFocus()
 			binding.surfaceView.setOnCapturedPointerListener { _, event ->
 				viewModel.input.onCapturedPointerEvent(event)
 			}

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -238,6 +238,19 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		}
 	}
 
+	// Pointer capture for a physical controller touchpad is normally established
+	// on window focus, but a controller (re)connecting MID-STREAM never changes
+	// window focus -- without this, a late-connected DualSense touchpad keeps
+	// acting as a system mouse. Re-evaluate capture whenever an input device
+	// connects or disconnects.
+	// "changed" matters too: a Bluetooth reconnect often announces the device
+	// before its touchpad source is fully populated.
+	private val touchpadCaptureDeviceListener = object: android.hardware.input.InputManager.InputDeviceListener {
+		override fun onInputDeviceAdded(deviceId: Int) { updatePhysicalTouchpadCapture() }
+		override fun onInputDeviceRemoved(deviceId: Int) { updatePhysicalTouchpadCapture() }
+		override fun onInputDeviceChanged(deviceId: Int) { updatePhysicalTouchpadCapture() }
+	}
+
 	override fun onResume()
 	{
 		super.onResume()
@@ -248,12 +261,16 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 		// it returns immediately when session != null
 		viewModel.session.resume()
 		updateStatsVisibility()
+		val inputManager = getSystemService(INPUT_SERVICE) as android.hardware.input.InputManager
+		inputManager.registerInputDeviceListener(touchpadCaptureDeviceListener, Handler(Looper.getMainLooper()))
 	}
 
 	override fun onPause()
 	{
 		super.onPause()
 		Log.i("StreamActivity", "onPause: pip=$isInPictureInPictureMode finishing=$isFinishing")
+		val inputManager = getSystemService(INPUT_SERVICE) as android.hardware.input.InputManager
+		inputManager.unregisterInputDeviceListener(touchpadCaptureDeviceListener)
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
 		{
 			binding.surfaceView.releasePointerCapture()

--- a/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/stream/StreamActivity.kt
@@ -184,8 +184,13 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 
 		if(Preferences(this).rumbleEnabled)
 		{
-			val vibrator = getSystemService(VIBRATOR_SERVICE) as Vibrator
+			val phoneVibrator = getSystemService(VIBRATOR_SERVICE) as Vibrator
 			viewModel.session.rumbleState.observe(this, Observer {
+				// Prefer the connected controller's own motor over the phone's
+				// (resolved per event so controller hotplug just works; the device
+				// list is tiny and rumble events are sparse). L/R are averaged into
+				// one amplitude because both targets expose a single channel here.
+				val vibrator = controllerVibrator() ?: phoneVibrator
 				val amplitude = min(255, (it.left.toInt() + it.right.toInt()) / 2)
 				vibrator.cancel()
 				if(amplitude == 0)
@@ -235,6 +240,11 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 	{
 		super.onPause()
 		Log.i("StreamActivity", "onPause: pip=$isInPictureInPictureMode finishing=$isFinishing")
+		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+		{
+			binding.surfaceView.releasePointerCapture()
+			viewModel.input.releaseCapturedTouchpad()
+		}
 		// In PiP mode the stream should keep running, so skip pause.
 		// isInPictureInPictureMode is the built-in Activity property.
 		if (!isInPictureInPictureMode)
@@ -486,7 +496,74 @@ class StreamActivity : AppCompatActivity(), View.OnSystemUiVisibilityChangeListe
 	{
 		super.onWindowFocusChanged(hasFocus)
 		if(hasFocus)
+		{
 			hideSystemUI()
+			updatePhysicalTouchpadCapture()
+		}
+	}
+
+	// The system releases pointer capture on its own (e.g. pulling the notification
+	// shade) without pausing us; drop any held touchpad touches so a finger can't
+	// stay stuck on the virtual pad until the next pause.
+	override fun onPointerCaptureChanged(hasCapture: Boolean)
+	{
+		super.onPointerCaptureChanged(hasCapture)
+		if(!hasCapture)
+			viewModel.input.releaseCapturedTouchpad()
+	}
+
+	/**
+	 * The connected gamepad's own vibrator, if it has one. VibratorManager on
+	 * API 31+, the legacy InputDevice.vibrator below that. Null when no attached
+	 * gamepad can rumble (caller falls back to the phone vibrator).
+	 */
+	private fun controllerVibrator(): Vibrator?
+		= InputDevice.getDeviceIds().asSequence()
+			.mapNotNull { InputDevice.getDevice(it) }
+			.filter {
+				it.sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
+					|| it.sources and InputDevice.SOURCE_CLASS_JOYSTICK == InputDevice.SOURCE_CLASS_JOYSTICK
+			}
+			.mapNotNull { dev ->
+				if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+					dev.vibratorManager.defaultVibrator.takeIf { it.hasVibrator() }
+				else
+					@Suppress("DEPRECATION") dev.vibrator.takeIf { it.hasVibrator() }
+			}
+			.firstOrNull()
+
+	/**
+	 * Physical controller touchpad (DualSense/DS4) support: Android only delivers
+	 * a controller touchpad's absolute finger positions to an app while a view
+	 * holds pointer capture (API 26+). Capture is requested only when a gamepad
+	 * that actually has a touchpad source is attached, so mice/laptop touchpads
+	 * are never hijacked. Re-evaluated on window-focus changes; released in
+	 * onPause. Below API 26 the physical pad is unavailable (the on-screen
+	 * touchpad overlay remains the touchpad path there).
+	 */
+	private fun updatePhysicalTouchpadCapture()
+	{
+		if(Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+			return
+		val hasControllerTouchpad = InputDevice.getDeviceIds().any { id ->
+			InputDevice.getDevice(id)?.let { dev ->
+				dev.sources and InputDevice.SOURCE_TOUCHPAD == InputDevice.SOURCE_TOUCHPAD
+					&& (dev.sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
+						|| dev.sources and InputDevice.SOURCE_CLASS_JOYSTICK == InputDevice.SOURCE_CLASS_JOYSTICK)
+			} ?: false
+		}
+		if(hasControllerTouchpad)
+		{
+			binding.surfaceView.setOnCapturedPointerListener { _, event ->
+				viewModel.input.onCapturedPointerEvent(event)
+			}
+			binding.surfaceView.requestPointerCapture()
+		}
+		else
+		{
+			binding.surfaceView.releasePointerCapture()
+			viewModel.input.releaseCapturedTouchpad()
+		}
 	}
 
 	private fun hideSystemUI()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -128,7 +128,7 @@
     <string name="preferences_dpad_touch_shortcut3_title">Touch Combo Button 3</string>
     <string name="preferences_dpad_touch_shortcut4_title">Touch Combo Button 4</string>
     <string name="preferences_rumble_enabled_title">Rumble</string>
-    <string name="preferences_rumble_enabled_summary">Use phone vibration motor for rumble</string>
+    <string name="preferences_rumble_enabled_summary">Rumble on the controller\'s motor when it has one, otherwise the phone</string>
     <string name="preferences_motion_enabled_title">Motion</string>
     <string name="preferences_motion_enabled_summary">Use device\'s motion sensors for controller motion</string>
     <string name="preferences_button_haptic_enabled_title">Touch Haptics</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -129,6 +129,8 @@
     <string name="preferences_dpad_touch_shortcut4_title">Touch Combo Button 4</string>
     <string name="preferences_rumble_enabled_title">Rumble</string>
     <string name="preferences_rumble_enabled_summary">Rumble on the controller\'s motor when it has one, otherwise the phone</string>
+    <string name="preferences_rumble_intensity_title">Rumble Intensity</string>
+    <string name="preferences_rumble_intensity_summary">Rumble strength (100 = normal, 0 = off, up to 500)</string>
     <string name="preferences_motion_enabled_title">Motion</string>
     <string name="preferences_motion_enabled_summary">Use device\'s motion sensors for controller motion</string>
     <string name="preferences_button_haptic_enabled_title">Touch Haptics</string>
@@ -269,6 +271,7 @@
     <string name="preferences_on_screen_controls_enabled_key">on_screen_controls_enabled</string>
     <string name="preferences_touchpad_only_enabled_key">touchpad_only_enabled</string>
     <string name="preferences_rumble_enabled_key">rumble_enabled</string>
+    <string name="preferences_rumble_intensity_key">rumble_intensity</string>
     <string name="preferences_motion_enabled_key">motion_enabled</string>
     <string name="preferences_button_haptic_enabled_key">button_haptic_enabled</string>
     <string name="preferences_log_verbose_key">log_verbose</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -131,8 +131,8 @@
     <string name="preferences_rumble_enabled_summary">Rumble on the controller\'s motor when it has one, otherwise the phone</string>
     <string name="preferences_rumble_intensity_title">Rumble Intensity</string>
     <string name="preferences_rumble_intensity_summary">Rumble strength (100 = normal, 0 = off, up to 500)</string>
-    <string name="preferences_motion_enabled_title">Motion</string>
-    <string name="preferences_motion_enabled_summary">Use device\'s motion sensors for controller motion</string>
+    <string name="preferences_motion_source_title">Gyro / Motion</string>
+    <string name="preferences_motion_source_summary">Motion sensors sent to the console for gyro aiming</string>
     <string name="preferences_button_haptic_enabled_title">Touch Haptics</string>
     <string name="preferences_button_haptic_enabled_summary">Use phone vibration motor for short haptic feedback on button touches</string>
     <string name="alert_message_delete_registered_host">Are you sure you want to delete the registered console %s with ID %s?</string>
@@ -234,6 +234,20 @@
         <item>16</item>
     </string-array>
 
+    <!-- Gyro / Motion source (matches iOS MotionSource) -->
+    <string-array name="motion_source_entries">
+        <item>Auto (controller, fall back to phone)</item>
+        <item>Controller only</item>
+        <item>Phone only</item>
+        <item>Off</item>
+    </string-array>
+    <string-array name="motion_source_values">
+        <item>auto</item>
+        <item>controller</item>
+        <item>phone</item>
+        <item>off</item>
+    </string-array>
+
     <!-- Datacenter options -->
     <string-array name="cloud_datacenter_entries">
         <item>Auto (Best Ping)</item>
@@ -272,7 +286,8 @@
     <string name="preferences_touchpad_only_enabled_key">touchpad_only_enabled</string>
     <string name="preferences_rumble_enabled_key">rumble_enabled</string>
     <string name="preferences_rumble_intensity_key">rumble_intensity</string>
-    <string name="preferences_motion_enabled_key">motion_enabled</string>
+    <string name="preferences_motion_enabled_key">motion_enabled</string> <!-- legacy bool, migrated into motion_source -->
+    <string name="preferences_motion_source_key">motion_source</string>
     <string name="preferences_button_haptic_enabled_key">button_haptic_enabled</string>
     <string name="preferences_log_verbose_key">log_verbose</string>
     <string name="preferences_import_settings_key">import_settings</string>

--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -55,10 +55,13 @@
             app:showSeekBarValue="true"
             app:icon="@drawable/ic_rumble" />
 
-        <SwitchPreference
-            app:key="@string/preferences_motion_enabled_key"
-            app:title="@string/preferences_motion_enabled_title"
-            app:summary="@string/preferences_motion_enabled_summary"
+        <ListPreference
+            app:key="@string/preferences_motion_source_key"
+            app:title="@string/preferences_motion_source_title"
+            app:summary="@string/preferences_motion_source_summary"
+            app:entries="@array/motion_source_entries"
+            app:entryValues="@array/motion_source_values"
+            app:defaultValue="auto"
             app:icon="@drawable/ic_motion" />
 
         <SwitchPreference

--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -43,6 +43,18 @@
             app:summary="@string/preferences_rumble_enabled_summary"
             app:icon="@drawable/ic_rumble" />
 
+        <SeekBarPreference
+            app:key="@string/preferences_rumble_intensity_key"
+            app:title="@string/preferences_rumble_intensity_title"
+            app:summary="@string/preferences_rumble_intensity_summary"
+            app:dependency="@string/preferences_rumble_enabled_key"
+            app:min="0"
+            android:max="500"
+            app:seekBarIncrement="10"
+            app:defaultValue="100"
+            app:showSeekBarValue="true"
+            app:icon="@drawable/ic_rumble" />
+
         <SwitchPreference
             app:key="@string/preferences_motion_enabled_key"
             app:title="@string/preferences_motion_enabled_title"

--- a/gui/include/streamsession.h
+++ b/gui/include/streamsession.h
@@ -422,6 +422,7 @@ class StreamSession : public QObject
 		void CantDisplayChanged(bool cant_display);
 		void LoadingMessageChanged();
 		void GameLaunchCompleted();
+		void PsChordFired(); // OPTIONS+SHARE chord fired -> open the in-stream menu
 
 	private slots:
 		void UpdateGamepads();

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -13,6 +13,7 @@ int main(int argc, char *argv[]) { return real_main(argc, argv); }
 #include <cloudstreamingbackend.h>
 #include <QApplication>
 #include <QMessageBox>
+#include <QStyleHints>
 #ifdef CHIAKI_ENABLE_STEAMWORKS
 #include <steamworks/steamworks_wrapper.h>
 #endif
@@ -138,6 +139,13 @@ int real_main(int argc, char *argv[])
 	QtWebEngineQuick::initialize();
 #endif
 	QApplication app(argc, argv);
+
+	// Controller/keyboard navigation moves focus with nextItemInFocusChain().
+	// On macOS the platform default (Full Keyboard Access off) excludes
+	// non-editable controls (combo boxes, checkboxes, sliders) from that chain,
+	// which left Up/Down navigation dead on any view without hand-written
+	// KeyNavigation chains. Treat all controls as tab-focusable everywhere.
+	QGuiApplication::styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
 
 #ifdef Q_OS_MACOS
 	QGuiApplication::setWindowIcon(QIcon(":/icons/chiaking_macos.svg"));

--- a/gui/src/qml/DialogView.qml
+++ b/gui/src/qml/DialogView.qml
@@ -56,11 +56,19 @@ Item {
         restoreFocusItem = Window.window.activeFocusItem;
     }
 
+    // Seed focus when this dialog becomes the active StackView page and there is
+    // no saved focus to restore. The generic tab-chain walk cannot reach the
+    // controls of every dialog (it lands on a non-control in SettingsDialog and
+    // would clobber that dialog's own seed) -- such dialogs override seedFocus.
+    function seedFocus() {
+        let item = mainItem.nextItemInFocusChain();
+        if (item)
+            item.forceActiveFocus(Qt.TabFocusReason);
+    }
+
     StackView.onActivated: {
         if (!restoreFocusItem) {
-            let item = mainItem.nextItemInFocusChain();
-            if (item)
-                item.forceActiveFocus(Qt.TabFocusReason);
+            dialog.seedFocus();
         } else {
             restoreFocusItem.forceActiveFocus(Qt.TabFocusReason);
             restoreFocusItem = null;

--- a/gui/src/qml/SettingsDialog.qml
+++ b/gui/src/qml/SettingsDialog.qml
@@ -201,7 +201,15 @@ DialogView {
                 topMargin: 10
             }
             currentIndex: bar.currentIndex
-            onCurrentIndexChanged: nextItemInFocusChain().forceActiveFocus(Qt.TabFocusReason)
+            // Focus the first control of the newly-shown tab so controller/keyboard
+            // Up/Down work immediately. MUST be deferred: running it synchronously on
+            // the index change lands focus on the tab that is not yet visible/laid out,
+            // so forceActiveFocus silently no-ops and nothing ends up focused -- which is
+            // why Down did nothing until you clicked a control. Qt.callLater runs it after
+            // the StackLayout has shown the new page. Also fired once for the initial tab.
+            function focusCurrentTab() { nextItemInFocusChain().forceActiveFocus(Qt.TabFocusReason); }
+            onCurrentIndexChanged: Qt.callLater(focusCurrentTab)
+            Component.onCompleted: Qt.callLater(focusCurrentTab)
 
             Item {
                 // General
@@ -2741,7 +2749,7 @@ DialogView {
                         visible: selectedCloudService == SettingsDialog.CloudService.PSCloud
                         KeyNavigation.right: datacenterPSCloud
                         KeyNavigation.up: cloudServiceSelection
-                        KeyNavigation.down: datacenterPSCloud
+                        KeyNavigation.down: cloudLanguage
                         KeyNavigation.priority: {
                             if(!popup.visible)
                                 KeyNavigation.BeforeItem
@@ -2781,7 +2789,7 @@ DialogView {
                         visible: selectedCloudService == SettingsDialog.CloudService.PSNOW
                         KeyNavigation.right: datacenterPSNOW
                         KeyNavigation.up: cloudServiceSelection
-                        KeyNavigation.down: datacenterPSNOW
+                        KeyNavigation.down: cloudLanguage
                         KeyNavigation.priority: {
                             if(!popup.visible)
                                 KeyNavigation.BeforeItem
@@ -2843,6 +2851,19 @@ DialogView {
                         onActivated: index => {
                             // "" (Auto) clears the override; otherwise store the pick.
                             Chiaki.settings.cloudGameLanguage = languageValues[index] || "";
+                        }
+                        // Thread this control into the cloud-tab focus chain, between
+                        // Resolution and Datacenter for whichever service is visible (it
+                        // shows for both PSCLOUD and PSNOW). priority BeforeItem so these
+                        // win over the ComboBox's own nextItemInFocusChain() default,
+                        // exactly like the sibling combos -- without it this row was skipped.
+                        KeyNavigation.up: selectedCloudService == SettingsDialog.CloudService.PSCloud ? resolutionPSCloud : resolutionPSNOW
+                        KeyNavigation.down: selectedCloudService == SettingsDialog.CloudService.PSCloud ? datacenterPSCloud : datacenterPSNOW
+                        KeyNavigation.priority: {
+                            if(!popup.visible)
+                                KeyNavigation.BeforeItem
+                            else
+                                KeyNavigation.AfterItem
                         }
                     }
 
@@ -2915,7 +2936,7 @@ DialogView {
                         }
                         visible: selectedCloudService == SettingsDialog.CloudService.PSCloud
                         KeyNavigation.left: resolutionPSCloud
-                        KeyNavigation.up: resolutionPSCloud
+                        KeyNavigation.up: cloudLanguage
                         KeyNavigation.down: cloudBitratePSCloud
                         KeyNavigation.priority: {
                             if(!popup.visible)
@@ -2981,7 +3002,7 @@ DialogView {
                         }
                         visible: selectedCloudService == SettingsDialog.CloudService.PSNOW
                         KeyNavigation.left: resolutionPSNOW
-                        KeyNavigation.up: resolutionPSNOW
+                        KeyNavigation.up: cloudLanguage
                         KeyNavigation.down: cloudBitratePSNOW
                         KeyNavigation.priority: {
                             if(!popup.visible)

--- a/gui/src/qml/SettingsDialog.qml
+++ b/gui/src/qml/SettingsDialog.qml
@@ -48,11 +48,19 @@ DialogView {
             event.accepted = true;
             break;
         case Qt.Key_Up:
-            event.accepted = false;
+        case Qt.Key_Down: {
+            // If focus hasn't landed on a tab control yet (still on the dialog
+            // root), seed it onto the current tab's first control instead of
+            // dropping the key. Otherwise let the focused control move focus.
+            let afi = dialog.Window.activeFocusItem;
+            if (!afi || afi === dialog) {
+                stackLayout.focusCurrentTab();
+                event.accepted = true;
+            } else {
+                event.accepted = false;
+            }
             break;
-        case Qt.Key_Down:
-            event.accepted = false;
-            break;
+        }
         }
     }
 
@@ -201,13 +209,37 @@ DialogView {
                 topMargin: 10
             }
             currentIndex: bar.currentIndex
-            // Focus the first control of the newly-shown tab so controller/keyboard
-            // Up/Down work immediately. MUST be deferred: running it synchronously on
-            // the index change lands focus on the tab that is not yet visible/laid out,
-            // so forceActiveFocus silently no-ops and nothing ends up focused -- which is
-            // why Down did nothing until you clicked a control. Qt.callLater runs it after
-            // the StackLayout has shown the new page. Also fired once for the initial tab.
-            function focusCurrentTab() { nextItemInFocusChain().forceActiveFocus(Qt.TabFocusReason); }
+            // Seed active focus onto the first control of the current tab so
+            // controller/keyboard Up/Down work as soon as the tab is shown. Every
+            // tab's first control is marked `firstInFocusChain: true`; find it by
+            // walking the current page's subtree. We do NOT use nextItemInFocusChain()
+            // here: called on the StackLayout it walks the Tab-focus order and lands on
+            // nothing, so no control ends up focused and Down does nothing until you
+            // click a control. Deferred with Qt.callLater so it runs after the newly
+            // current page has been laid out. Also fired once for the initial tab.
+            function findFirstInFocusChain(item, anyControl) {
+                if (!item || item.visible === false)
+                    return null;
+                var isMatch = anyControl ? (item.firstInFocusChain !== undefined)
+                                         : (item.firstInFocusChain === true);
+                if (isMatch && item.enabled)
+                    return item;
+                var kids = item.children;
+                for (var i = 0; kids && i < kids.length; ++i) {
+                    var found = findFirstInFocusChain(kids[i], anyControl);
+                    if (found)
+                        return found;
+                }
+                return null;
+            }
+            function focusCurrentTab() {
+                var page = stackLayout.children[stackLayout.currentIndex];
+                // Prefer the tab's explicitly-marked first control; fall back to the
+                // first custom control on the page so no tab is ever left unfocusable.
+                var target = findFirstInFocusChain(page) || findFirstInFocusChain(page, true);
+                if (target)
+                    target.forceActiveFocus(Qt.TabFocusReason);
+            }
             onCurrentIndexChanged: Qt.callLater(focusCurrentTab)
             Component.onCompleted: Qt.callLater(focusCurrentTab)
 
@@ -579,6 +611,7 @@ DialogView {
 
                     C.ComboBox {
                         Layout.preferredWidth: 400
+                        firstInFocusChain: true
                         model: Chiaki.settings.availableDecoders
                         currentIndex: Math.max(0, model.indexOf(Chiaki.settings.decoder))
                         onActivated: (index) => Chiaki.settings.decoder = index ? model[index] : ""

--- a/gui/src/qml/SettingsDialog.qml
+++ b/gui/src/qml/SettingsDialog.qml
@@ -25,6 +25,13 @@ DialogView {
     title: qsTr("Settings")
     header: qsTr("* Defaults in () to right of value or marked with (Default)")
     buttonVisible: false
+    // Override DialogView's activation seed: its generic tab-chain walk does not
+    // resolve to a settings control here, so it used to clobber the tab-aware
+    // seed right after the push transition finished -- leaving nothing focused
+    // until a control was clicked. Land on the current tab's first control.
+    function seedFocus() {
+        stackLayout.focusCurrentTab();
+    }
     Keys.onPressed: (event) => {
         if (event.modifiers)
             return;
@@ -49,11 +56,12 @@ DialogView {
             break;
         case Qt.Key_Up:
         case Qt.Key_Down: {
-            // If focus hasn't landed on a tab control yet (still on the dialog
-            // root), seed it onto the current tab's first control instead of
-            // dropping the key. Otherwise let the focused control move focus.
+            // If focus is not on one of the tab's controls (dialog root, or a
+            // stray target left by a failed or clobbered seed), seed it onto the
+            // current tab's first control instead of dropping the key. Every
+            // focusable settings control declares firstInFocusChain.
             let afi = dialog.Window.activeFocusItem;
-            if (!afi || afi === dialog) {
+            if (!afi || afi.firstInFocusChain === undefined) {
                 stackLayout.focusCurrentTab();
                 event.accepted = true;
             } else {
@@ -233,6 +241,12 @@ DialogView {
                 return null;
             }
             function focusCurrentTab() {
+                // Only seed while this dialog is (becoming) the StackView's current
+                // page -- seeding while hidden would steal focus from whatever
+                // screen is actually visible.
+                var status = dialog.StackView.status;
+                if (status !== StackView.Active && status !== StackView.Activating)
+                    return;
                 var page = stackLayout.children[stackLayout.currentIndex];
                 // Prefer the tab's explicitly-marked first control; fall back to the
                 // first custom control on the page so no tab is ever left unfocusable.

--- a/gui/src/qmlmainwindow.cpp
+++ b/gui/src/qmlmainwindow.cpp
@@ -555,6 +555,12 @@ void QmlMainWindow::init(Settings *settings, bool exit_app_on_stream_exit, Steam
         {
             connect(session, &StreamSession::SessionQuit, qGuiApp, &QGuiApplication::quit);
         }
+        if(session)
+        {
+            // OPTIONS+SHARE chord fired -> open the in-stream menu, same as Ctrl+O,
+            // so a controller-only player can reach disconnect/stats without a keyboard.
+            connect(session, &StreamSession::PsChordFired, this, &QmlMainWindow::menuRequested, Qt::QueuedConnection);
+        }
         if(!session)
         {
             setStreamWindowAdjustable(false);

--- a/gui/src/streamsession.cpp
+++ b/gui/src/streamsession.cpp
@@ -454,6 +454,7 @@ StreamSession::StreamSession(const StreamSessionConnectInfo &connect_info, QObje
 	err = chiaki_session_init(&session, &chiaki_connect_info, GetChiakiLog());
 	if(err != CHIAKI_ERR_SUCCESS)
 		throw ChiakiException("Chiaki Session Init failed: " + QString::fromLocal8Bit(chiaki_error_string(err)));
+	chiaki_session_set_ps_chord(&session, true, 0); // always on: safe, no user toggle
 	ChiakiCtrlDisplaySink display_sink;
 	display_sink.user = this;
 	display_sink.cantdisplay_cb = CantDisplayCb;

--- a/gui/src/streamsession.cpp
+++ b/gui/src/streamsession.cpp
@@ -1951,6 +1951,13 @@ void StreamSession::Event(ChiakiEvent *event)
 			connected = true;
 			emit ConnectedChanged();
 			break;
+		case CHIAKI_EVENT_PS_CHORD:
+			// OPTIONS+SHARE chord fired. The synthesized PS pulse already went to
+			// the console via the feedback sender; also surface our in-stream menu
+			// so a controller-only player can reach disconnect/stats.
+			CHIAKI_LOGI(GetChiakiLog(), "PS chord fired -> requesting in-stream menu");
+			emit PsChordFired();
+			break;
 		case CHIAKI_EVENT_QUIT:
 			// Do not auto-retry when the console reports RP crashed or session in use — rapid
 			// sess/init loops stress the console and match the repeated 403 + 0x80108b15 pattern.

--- a/ios/Pylux.xcodeproj/project.pbxproj
+++ b/ios/Pylux.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		A1000145 /* PyluxAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000146 /* PyluxAppDelegate.swift */; };
 		A1000147 /* StreamTouchControlsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000148 /* StreamTouchControlsOverlay.swift */; };
 		A1000151 /* StreamRumbleFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000152 /* StreamRumbleFeedback.swift */; };
+		A1000161 /* StreamTriggerFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000160 /* StreamTriggerFeedback.swift */; };
 		A1000163 /* ControlSVGPathParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000164 /* ControlSVGPathParser.swift */; };
 		A1000165 /* StreamTouchControlsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000166 /* StreamTouchControlsTypes.swift */; };
 		A1000167 /* StreamTouchControlsStickDPad.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000168 /* StreamTouchControlsStickDPad.swift */; };
@@ -110,6 +111,7 @@
 		A1000146 /* PyluxAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyluxAppDelegate.swift; sourceTree = "<group>"; };
 		A1000148 /* StreamTouchControlsOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamTouchControlsOverlay.swift; sourceTree = "<group>"; };
 		A1000152 /* StreamRumbleFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamRumbleFeedback.swift; sourceTree = "<group>"; };
+		A1000160 /* StreamTriggerFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamTriggerFeedback.swift; sourceTree = "<group>"; };
 		A1000164 /* ControlSVGPathParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlSVGPathParser.swift; sourceTree = "<group>"; };
 		A1000166 /* StreamTouchControlsTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamTouchControlsTypes.swift; sourceTree = "<group>"; };
 		A1000168 /* StreamTouchControlsStickDPad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamTouchControlsStickDPad.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				A1000025 /* StreamSession.swift */,
 				A1000027 /* StreamInput.swift */,
 				A1000152 /* StreamRumbleFeedback.swift */,
+				A1000160 /* StreamTriggerFeedback.swift */,
 				A6000001 /* AppReviewHelper.swift */,
 			);
 			path = Services;
@@ -373,6 +376,7 @@
 				A1000010 /* StreamState.swift in Sources */,
 				A1000028 /* StreamInput.swift in Sources */,
 				A1000151 /* StreamRumbleFeedback.swift in Sources */,
+				A1000161 /* StreamTriggerFeedback.swift in Sources */,
 				A1000037 /* StreamView.swift in Sources */,
 				A1000147 /* StreamTouchControlsOverlay.swift in Sources */,
 				A1000165 /* StreamTouchControlsTypes.swift in Sources */,

--- a/ios/Pylux/Bridge/ChiakiSessionBridge.h
+++ b/ios/Pylux/Bridge/ChiakiSessionBridge.h
@@ -35,6 +35,7 @@ typedef enum {
     ChiakiSessionBridgeEventPlayerIndex = 13,
     ChiakiSessionBridgeEventHapticIntensity = 14,
     ChiakiSessionBridgeEventTriggerIntensity = 15,
+    ChiakiSessionBridgeEventPsChord = 16, // OPTIONS+SHARE chord fired -> surface the in-stream menu
 } ChiakiSessionBridgeEventType;
 
 /**

--- a/ios/Pylux/Bridge/ChiakiSessionBridge.h
+++ b/ios/Pylux/Bridge/ChiakiSessionBridge.h
@@ -54,6 +54,13 @@ typedef struct ChiakiSessionBridgeEvent {
     uint8_t regist_rp_regist_key[16];    // CHIAKI_SESSION_AUTH_SIZE
     uint32_t regist_rp_key_type;
     uint8_t regist_rp_key[16];
+    // DualSense adaptive triggers (when type == TriggerEffects): the raw PS5
+    // trigger-effect descriptors (mode byte + 10 param bytes per trigger), decoded
+    // to GCDualSenseAdaptiveTrigger calls on the Swift side.
+    uint8_t trigger_type_left;
+    uint8_t trigger_type_right;
+    uint8_t trigger_left[10];
+    uint8_t trigger_right[10];
 } ChiakiSessionBridgeEvent;
 
 /**
@@ -75,6 +82,7 @@ typedef struct ChiakiSessionBridgeConnectInfo {
     unsigned int video_max_fps;
     unsigned int video_bitrate;
     int video_codec; // 0=H264, 1=H265, 2=H265_HDR
+    bool enable_dualsense; // request DualSense haptics/adaptive-trigger data from the console
     // PSN holepunch fields (optional, 0/NULL for local connections)
     uintptr_t holepunch_session;  // ChiakiHolepunchSession ptr (owned by native session after create)
     bool auto_regist;
@@ -135,6 +143,20 @@ int chiaki_session_bridge_join(ChiakiSessionRef ref);
  * Set controller state. state layout must match ChiakiControllerState.
  */
 int chiaki_session_bridge_set_controller_state(ChiakiSessionRef ref, const void *state);
+
+/**
+ * Configure the OPTIONS+SHARE -> PS button chord (see chiaki_session_set_ps_chord).
+ * hold_ms == 0 keeps the default hold duration.
+ */
+void chiaki_session_bridge_set_ps_chord(ChiakiSessionRef ref, bool enabled, uint32_t hold_ms);
+
+/**
+ * Register a haptics sink that converts DualSense haptic-audio frames back into
+ * rumble events. Call only when streaming with enable_dualsense = true (a
+ * DualSense connected), so classic rumble isn't lost when the console switches to
+ * haptic-audio delivery.
+ */
+void chiaki_session_bridge_enable_haptics_rumble(ChiakiSessionRef ref);
 
 /**
  * Set login PIN (e.g. when LoginPinRequest event received).

--- a/ios/Pylux/Bridge/ChiakiSessionBridge.h
+++ b/ios/Pylux/Bridge/ChiakiSessionBridge.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <chiaki/controller.h>
+#include <chiaki/orientation.h>
 
 /**
  * Opaque session reference. Create with chiaki_session_bridge_create, free with chiaki_session_bridge_free.
@@ -62,6 +63,10 @@ typedef struct ChiakiSessionBridgeEvent {
     uint8_t trigger_type_right;
     uint8_t trigger_left[10];
     uint8_t trigger_right[10];
+    // For HapticIntensity/TriggerIntensity events: the console's per-session
+    // DualSense intensity setting (ChiakiDualSenseEffectIntensity:
+    // 0=Off, 1=Strong, 2=Medium, 3=Weak).
+    int effect_intensity;
 } ChiakiSessionBridgeEvent;
 
 /**
@@ -153,9 +158,8 @@ void chiaki_session_bridge_set_ps_chord(ChiakiSessionRef ref, bool enabled, uint
 
 /**
  * Register a haptics sink that converts DualSense haptic-audio frames back into
- * rumble events. Call only when streaming with enable_dualsense = true (a
- * DualSense connected), so classic rumble isn't lost when the console switches to
- * haptic-audio delivery.
+ * rumble events. Required for Remote Play rumble (a PS5 delivers rumble ONLY as
+ * haptic audio when enable_dualsense = true); harmless for cloud sessions.
  */
 void chiaki_session_bridge_enable_haptics_rumble(ChiakiSessionRef ref);
 

--- a/ios/Pylux/Bridge/ChiakiSessionBridge.m
+++ b/ios/Pylux/Bridge/ChiakiSessionBridge.m
@@ -29,6 +29,7 @@ typedef struct {
     char *cloud_handshake_key_copy;
     ChiakiSessionBridgeEventCallback event_cb;
     void *event_user;
+    uint8_t last_haptic_amp; // throttles the haptics->rumble bridge (emit only on change)
     bool (*video_sample_cb)(uint8_t *buf, size_t buf_size, int32_t frames_lost, bool frame_recovered, void *user);
     void *video_sample_cb_user;
 #if CHIAKI_LIB_ENABLE_OPUS
@@ -76,7 +77,16 @@ static void event_cb_chiaki(ChiakiEvent *event, void *user)
             bridge_event.regist_rp_key_type = event->host.rp_key_type;
             memcpy(bridge_event.regist_rp_key, event->host.rp_key, 16);
             break;
+        case CHIAKI_EVENT_TRIGGER_EFFECTS:
+            bridge_event.trigger_type_left = event->trigger_effects.type_left;
+            bridge_event.trigger_type_right = event->trigger_effects.type_right;
+            memcpy(bridge_event.trigger_left, event->trigger_effects.left, sizeof(bridge_event.trigger_left));
+            memcpy(bridge_event.trigger_right, event->trigger_effects.right, sizeof(bridge_event.trigger_right));
+            break;
         default:
+            // Other DualSense feedback (HAPTIC_INTENSITY, TRIGGER_INTENSITY, LED,
+            // PLAYER_INDEX, MOTION_RESET) isn't surfaced yet; the bridge event type
+            // still maps 1:1 with ChiakiEventType so Swift can see them if needed.
             break;
     }
     s->event_cb(&bridge_event, s->event_user);
@@ -167,6 +177,7 @@ ChiakiSessionRef chiaki_session_bridge_create(const ChiakiSessionBridgeConnectIn
     ci.video_profile.max_fps = connect_info->video_max_fps;
     ci.video_profile.bitrate = connect_info->video_bitrate;
     ci.video_profile.codec = (ChiakiCodec)codec_from_int(connect_info->video_codec);
+    ci.enable_dualsense = connect_info->enable_dualsense;
     ci.video_profile_auto_downgrade = true;
     ci.audio_video_disabled = CHIAKI_NONE_DISABLED;
     ci.holepunch_session = (ChiakiHolepunchSession)connect_info->holepunch_session;
@@ -301,6 +312,57 @@ int chiaki_session_bridge_set_controller_state(ChiakiSessionRef ref, const void 
 {
     if (!ref || !state) return CHIAKI_ERR_INVALID_DATA;
     return (int)chiaki_session_set_controller_state(((iOSChiakiSession *)ref)->session, (ChiakiControllerState *)state);
+}
+
+// When enable_dualsense is on, a PS5 delivers rumble as DualSense HAPTIC AUDIO
+// frames (not classic rumble packets). We aren't playing rich DualSense body
+// haptics here, but to avoid losing rumble entirely we convert the haptic PCM to
+// a single amplitude (same approach as the Qt client) and re-emit it as a normal
+// Rumble bridge event, so the existing Swift rumble path drives the controller.
+static void haptics_frame_cb_chiaki(uint8_t *buf, size_t buf_size, void *user)
+{
+    iOSChiakiSession *s = (iOSChiakiSession *)user;
+    if (!s->event_cb || !buf)
+        return;
+    const size_t sample_size = 2 * sizeof(int16_t); // interleaved stereo int16
+    size_t n = buf_size / sample_size;
+    if (n == 0)
+        return;
+    uint64_t sum = 0;
+    for (size_t i = 0; i < n; i++)
+    {
+        int16_t l = 0, r = 0;
+        memcpy(&l, buf + i * sample_size, sizeof(int16_t));
+        memcpy(&r, buf + i * sample_size + sizeof(int16_t), sizeof(int16_t));
+        int al = l < 0 ? -l : l, ar = r < 0 ? -r : r;
+        sum += (uint64_t)(al > ar ? al : ar);
+    }
+    uint32_t avg = (uint32_t)(sum / n); // 0..32767
+    uint8_t amp = avg >= 32767 ? 255 : (uint8_t)((avg * 255) / 32767);
+    if (amp == s->last_haptic_amp)
+        return; // only emit on meaningful change (throttle main-thread churn)
+    s->last_haptic_amp = amp;
+    ChiakiSessionBridgeEvent ev = { 0 };
+    ev.type = ChiakiSessionBridgeEventRumble;
+    ev.rumble_left = amp;
+    ev.rumble_right = amp;
+    s->event_cb(&ev, s->event_user);
+}
+
+void chiaki_session_bridge_enable_haptics_rumble(ChiakiSessionRef ref)
+{
+    iOSChiakiSession *s = (iOSChiakiSession *)ref;
+    if (!s) return;
+    ChiakiAudioSink sink = { 0 };
+    sink.user = s;
+    sink.frame_cb = haptics_frame_cb_chiaki;
+    chiaki_session_set_haptics_sink(s->session, &sink);
+}
+
+void chiaki_session_bridge_set_ps_chord(ChiakiSessionRef ref, bool enabled, uint32_t hold_ms)
+{
+    if (!ref) return;
+    chiaki_session_set_ps_chord(((iOSChiakiSession *)ref)->session, enabled, hold_ms);
 }
 
 void chiaki_session_bridge_get_metrics(ChiakiSessionRef ref, ChiakiSessionBridgeMetrics *out)

--- a/ios/Pylux/Bridge/ChiakiSessionBridge.m
+++ b/ios/Pylux/Bridge/ChiakiSessionBridge.m
@@ -30,6 +30,7 @@ typedef struct {
     ChiakiSessionBridgeEventCallback event_cb;
     void *event_user;
     uint8_t last_haptic_amp; // throttles the haptics->rumble bridge (emit only on change)
+    uint16_t haptic_same_amp_frames; // consecutive frames suppressed by the throttle
     bool (*video_sample_cb)(uint8_t *buf, size_t buf_size, int32_t frames_lost, bool frame_recovered, void *user);
     void *video_sample_cb_user;
 #if CHIAKI_LIB_ENABLE_OPUS
@@ -345,8 +346,15 @@ static void haptics_frame_cb_chiaki(uint8_t *buf, size_t buf_size, void *user)
     }
     uint32_t avg = (uint32_t)(sum / n); // 0..32767
     uint8_t amp = avg >= 32767 ? 255 : (uint8_t)((avg * 255) / 32767);
-    if (amp == s->last_haptic_amp)
-        return; // only emit on meaningful change (throttle main-thread churn)
+    // Only emit on change -- but the consumer plays a FINITE (1s) haptic pattern,
+    // so a constant non-zero amplitude sustained past that would go silent. Let
+    // equal amplitudes through periodically to re-arm the effect (~every 0.5s at
+    // the ~100 frames/s haptic rate).
+    if (amp == s->last_haptic_amp) {
+        if (amp == 0 || ++s->haptic_same_amp_frames < 50)
+            return;
+    }
+    s->haptic_same_amp_frames = 0;
     s->last_haptic_amp = amp;
     ChiakiSessionBridgeEvent ev = { 0 };
     ev.type = ChiakiSessionBridgeEventRumble;

--- a/ios/Pylux/Bridge/ChiakiSessionBridge.m
+++ b/ios/Pylux/Bridge/ChiakiSessionBridge.m
@@ -83,10 +83,16 @@ static void event_cb_chiaki(ChiakiEvent *event, void *user)
             memcpy(bridge_event.trigger_left, event->trigger_effects.left, sizeof(bridge_event.trigger_left));
             memcpy(bridge_event.trigger_right, event->trigger_effects.right, sizeof(bridge_event.trigger_right));
             break;
+        case CHIAKI_EVENT_HAPTIC_INTENSITY:
+        case CHIAKI_EVENT_TRIGGER_INTENSITY:
+            // Console's per-session DualSense intensity settings; Swift scales
+            // rumble amplitude / trigger effects with these (matching Qt).
+            bridge_event.effect_intensity = (int)event->intensity;
+            break;
         default:
-            // Other DualSense feedback (HAPTIC_INTENSITY, TRIGGER_INTENSITY, LED,
-            // PLAYER_INDEX, MOTION_RESET) isn't surfaced yet; the bridge event type
-            // still maps 1:1 with ChiakiEventType so Swift can see them if needed.
+            // Other DualSense feedback (LED, PLAYER_INDEX, MOTION_RESET) isn't
+            // surfaced yet; the bridge event type still maps 1:1 with
+            // ChiakiEventType so Swift can see them if needed.
             break;
     }
     s->event_cb(&bridge_event, s->event_user);
@@ -356,7 +362,13 @@ void chiaki_session_bridge_enable_haptics_rumble(ChiakiSessionRef ref)
     ChiakiAudioSink sink = { 0 };
     sink.user = s;
     sink.frame_cb = haptics_frame_cb_chiaki;
-    chiaki_session_set_haptics_sink(s->session, &sink);
+    // MUST be the _ex variant: chiaki_session_set_haptics_sink is static inline,
+    // so calling it from this ObjC translation unit computes the haptics_sink
+    // offset from THIS file's view of ChiakiSession -- which differs from the
+    // library's (different config defines; same reason the session is allocated
+    // via chiaki_session_get_sizeof). The inline version wrote the sink pointer
+    // to the wrong offset, the lib read NULL, and RP rumble stayed silent.
+    chiaki_session_set_haptics_sink_ex(s->session, &sink);
 }
 
 void chiaki_session_bridge_set_ps_chord(ChiakiSessionRef ref, bool enabled, uint32_t hold_ms)

--- a/ios/Pylux/Bridge/VideoDecoder.m
+++ b/ios/Pylux/Bridge/VideoDecoder.m
@@ -122,33 +122,37 @@ static BOOL findNextNAL(const uint8_t *data, size_t size, size_t *startOut, size
     // one corrupt "NAL" with an embedded start code, which hardware VideoToolbox
     // rejects (-12909) for every frame.
     size_t i = 0;
-    size_t nalStart = 0;
-    BOOL found = NO;
     while (i + 3 <= size) {
-        if (data[i] == 0 && data[i+1] == 0 && data[i+2] == 1) {
+        size_t nalStart;
+        if (data[i] == 0 && data[i+1] == 0 && data[i+2] == 1)
             nalStart = i + 3;
-            found = YES;
-            break;
-        }
-        if (i + 4 <= size && data[i] == 0 && data[i+1] == 0 && data[i+2] == 0 && data[i+3] == 1) {
+        else if (i + 4 <= size && data[i] == 0 && data[i+1] == 0 && data[i+2] == 0 && data[i+3] == 1)
             nalStart = i + 4;
-            found = YES;
-            break;
+        else {
+            i++;
+            continue;
         }
-        i++;
+        if (nalStart >= size) return NO;
+        size_t j = nalStart;
+        while (j + 3 <= size) {
+            if (data[j] == 0 && data[j+1] == 0
+                && (data[j+2] == 1 || (j + 4 <= size && data[j+2] == 0 && data[j+3] == 1)))
+                break;
+            j++;
+        }
+        size_t nalEnd = (j + 3 <= size) ? j : size;
+        if (nalEnd == nalStart) {
+            // Adjacent start codes (zero-length NAL, only in malformed streams):
+            // skip past it and keep scanning instead of dropping the rest of the
+            // buffer's NALs.
+            i = nalStart;
+            continue;
+        }
+        *startOut = nalStart;
+        *lenOut = nalEnd - nalStart;
+        return YES;
     }
-    if (!found || nalStart >= size) return NO;
-    size_t j = nalStart;
-    while (j + 3 <= size) {
-        if (data[j] == 0 && data[j+1] == 0
-            && (data[j+2] == 1 || (j + 4 <= size && data[j+2] == 0 && data[j+3] == 1)))
-            break;
-        j++;
-    }
-    size_t nalEnd = (j + 3 <= size) ? j : size;
-    *startOut = nalStart;
-    *lenOut = nalEnd - nalStart;
-    return *lenOut > 0;
+    return NO;
 }
 
 static uint8_t h264NALType(const uint8_t *nal, size_t len) {

--- a/ios/Pylux/Bridge/VideoDecoder.m
+++ b/ios/Pylux/Bridge/VideoDecoder.m
@@ -114,35 +114,41 @@ static void outputCallback(void *decompressionOutputRefCon,
 }
 
 static BOOL findNextNAL(const uint8_t *data, size_t size, size_t *startOut, size_t *lenOut) {
+    // A NAL begins after a 3-byte (00 00 01) or 4-byte (00 00 00 01) start code
+    // and ends at the next start code OF EITHER STYLE (or the buffer end).
+    // Streams freely mix styles within one access unit — PSNOW PS3 frames carry
+    // slice 1 behind a 4-byte code and slice 2 behind a 3-byte code. Scanning
+    // only for the same style (as this function once did) merges the slices into
+    // one corrupt "NAL" with an embedded start code, which hardware VideoToolbox
+    // rejects (-12909) for every frame.
     size_t i = 0;
-    while (i + 4 <= size) {
+    size_t nalStart = 0;
+    BOOL found = NO;
+    while (i + 3 <= size) {
         if (data[i] == 0 && data[i+1] == 0 && data[i+2] == 1) {
-            size_t nalStart = (data[i+3] == 0) ? i + 4 : i + 3;
-            size_t j = nalStart;
-            while (j + 3 <= size) {
-                if (data[j] == 0 && data[j+1] == 0 && (data[j+2] == 1 || (data[j+2] == 0 && j+4 <= size && data[j+3] == 1)))
-                    break;
-                j++;
-            }
-            *startOut = nalStart;
-            *lenOut = (j + 3 <= size) ? (j - nalStart) : (size - nalStart);
-            return YES;
+            nalStart = i + 3;
+            found = YES;
+            break;
         }
-        if (data[i] == 0 && data[i+1] == 0 && data[i+2] == 0 && i+4 <= size && data[i+3] == 1) {
-            size_t nalStart = i + 4;
-            size_t j = nalStart;
-            while (j + 4 <= size) {
-                if (data[j] == 0 && data[j+1] == 0 && data[j+2] == 0 && data[j+3] == 1)
-                    break;
-                j++;
-            }
-            *startOut = nalStart;
-            *lenOut = (j + 4 <= size) ? (j - nalStart) : (size - nalStart);
-            return YES;
+        if (i + 4 <= size && data[i] == 0 && data[i+1] == 0 && data[i+2] == 0 && data[i+3] == 1) {
+            nalStart = i + 4;
+            found = YES;
+            break;
         }
         i++;
     }
-    return NO;
+    if (!found || nalStart >= size) return NO;
+    size_t j = nalStart;
+    while (j + 3 <= size) {
+        if (data[j] == 0 && data[j+1] == 0
+            && (data[j+2] == 1 || (j + 4 <= size && data[j+2] == 0 && data[j+3] == 1)))
+            break;
+        j++;
+    }
+    size_t nalEnd = (j + 3 <= size) ? j : size;
+    *startOut = nalStart;
+    *lenOut = nalEnd - nalStart;
+    return *lenOut > 0;
 }
 
 static uint8_t h264NALType(const uint8_t *nal, size_t len) {

--- a/ios/Pylux/Info.plist
+++ b/ios/Pylux/Info.plist
@@ -6,6 +6,15 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>GCSupportsControllerUserInteraction</key>
+	<true/>
+	<key>GCSupportedGameControllers</key>
+	<array>
+		<dict>
+			<key>ProfileName</key>
+			<string>ExtendedGamepad</string>
+		</dict>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/ios/Pylux/Models/HostModels.swift
+++ b/ios/Pylux/Models/HostModels.swift
@@ -434,10 +434,18 @@ class HostStore: ObservableObject {
         guard let registered = host.registeredHost else { return }
         let address = host.hostAddress
         guard !address.isEmpty else { return }
-        // Wakeup credential = first 8 bytes of rpRegistKey as big-endian UInt64
-        // Matches Android: credential = BigInteger(1, rpRegistKey.take(8).toByteArray()).toLong()
-        let keyBytes = registered.rpRegistKey.prefix(8)
-        let credential = keyBytes.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+        // Wakeup credential: the regist key's CONTENT is an ASCII hex string --
+        // parse it as hex, like Android (registKeyString.toULong(16)) and Qt
+        // (strtoull(..., 16)). Packing the raw ASCII bytes into an integer (the
+        // previous code here) sent a credential matching no registered client,
+        // which the console silently ignored: wake worked on Android but not iOS.
+        let keyData = registered.rpRegistKey.prefix(while: { $0 != 0 })
+        guard let keyString = String(data: keyData, encoding: .utf8),
+              let credential = UInt64(keyString, radix: 16)
+        else {
+            os_log(.error, log: hostLog, "Wakeup: regist key is not a hex string, cannot wake")
+            return
+        }
         os_log(.info, log: hostLog, "Wakeup: sending to %{public}s, credential=0x%016llx, ps5=%d",
                address, credential, registered.isPS5 ? 1 : 0)
         PyluxDiscoveryService.wakeupHost(address, credential: credential, ps5: registered.isPS5)

--- a/ios/Pylux/Models/HostModels.swift
+++ b/ios/Pylux/Models/HostModels.swift
@@ -191,7 +191,7 @@ class HostStore: ObservableObject {
             psnHosts.map { ($0.name, $0.duid) },
             uniquingKeysWith: { _, last in last }
         )
-        os_log(.default, log: hostLog, "displayHosts: %d discovered, %d psn, %d manual, %d registered",
+        os_log(.info, log: hostLog, "displayHosts: %d discovered, %d psn, %d manual, %d registered",
                discoveredHosts.count, psnHosts.count, manualHosts.count, registeredHosts.count)
 
         let discovered: [DisplayHost] = discoveredHosts.map { dh in
@@ -210,7 +210,7 @@ class HostStore: ObservableObject {
             // Cross-reference: if this discovered host also exists in PSN hosts, carry its DUID
             // (matches Android MainViewModel line 83: psnDuid = matchedDuid)
             let matchedDuid = dh.hostName.flatMap { psnDuidByNickname[$0] }
-            os_log(.default, log: hostLog, "  discovered: name=%{public}s hostId=%{public}s registered=%d",
+            os_log(.info, log: hostLog, "  discovered: name=%{public}s hostId=%{public}s registered=%d",
                    dh.hostName ?? "nil", dh.hostId ?? "nil", registered != nil ? 1 : 0)
             return .discovered(DiscoveredDisplayHost(registeredHost: registered, discoveredHost: dh, psnDuid: matchedDuid))
         }
@@ -438,7 +438,7 @@ class HostStore: ObservableObject {
         // Matches Android: credential = BigInteger(1, rpRegistKey.take(8).toByteArray()).toLong()
         let keyBytes = registered.rpRegistKey.prefix(8)
         let credential = keyBytes.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
-        os_log(.default, log: hostLog, "Wakeup: sending to %{public}s, credential=0x%016llx, ps5=%d",
+        os_log(.info, log: hostLog, "Wakeup: sending to %{public}s, credential=0x%016llx, ps5=%d",
                address, credential, registered.isPS5 ? 1 : 0)
         PyluxDiscoveryService.wakeupHost(address, credential: credential, ps5: registered.isPS5)
     }

--- a/ios/Pylux/Services/StreamInput.swift
+++ b/ios/Pylux/Services/StreamInput.swift
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
 // Merges physical `GameController` input with on-screen touch controls into `ChiakiControllerState` (Android `StreamInput`).
 
+import CoreMotion
 import Foundation
 import GameController
-
-// TODO: Device motion when `StreamPreferences.motionEnabled` (Android parity).
 
 /// Owns merged `ChiakiControllerState` and notifies `StreamSession` when it changes.
 /// Merges are **event-driven** like Android: touch overlay updates, `GCController` `valueChangedHandler`,
@@ -28,22 +27,30 @@ class StreamInput {
     private weak var attachedController: GCController?
     private var lastStateHash: Int = -1
     private let swapButtons: Bool
+    // Motion (gyro/accel/orientation) streamed to the console, per the user's
+    // MotionSource setting: the controller's sensors (GCMotion), this device's
+    // sensors (CoreMotion), or off. Raw gyro/accel are fed through the shared C
+    // orientation tracker exactly like Qt's SDL path.
+    private var motionSource: MotionSource
+    private var orientationTracker = ChiakiOrientationTracker()
+    private var accelZero = ChiakiAccelNewZero()
+    private let deviceMotion = CMMotionManager()
+    private var prefsObserver: NSObjectProtocol?
 
     /// The currently attached physical controller (if any). Used by `StreamRumbleFeedback` to route haptics.
     var currentController: GCController? { attachedController ?? GCController.controllers().first }
 
-    /// True when the attached controller is a physical DualSense. Gates
-    /// `enable_dualsense`: only advertise DualSense to the console when one is
-    /// actually connected, so non-DualSense users keep classic rumble.
-    var hasDualSense: Bool { (currentController?.extendedGamepad as? GCDualSenseGamepad) != nil }
-
     // MARK: - Lifecycle
 
     init() {
-        swapButtons = StreamPreferences.load().swapCrossMoon
+        let prefs = StreamPreferences.load()
+        swapButtons = prefs.swapCrossMoon
+        motionSource = prefs.motionSource
         chiaki_controller_state_set_idle(&controllerState)
         chiaki_controller_state_set_idle(&touchOverlayState)
         chiaki_controller_state_set_idle(&physicalTouchpadState)
+        chiaki_orientation_tracker_init(&orientationTracker)
+        chiaki_accel_new_zero_set_inactive(&accelZero, false)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(controllerDidConnect),
@@ -56,13 +63,28 @@ class StreamInput {
             name: .GCControllerDidDisconnect,
             object: nil
         )
+        prefsObserver = NotificationCenter.default.addObserver(
+            forName: .streamPreferencesDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            self.motionSource = StreamPreferences.load().motionSource
+            self.reconfigureMotionSources()
+        }
         if let controller = GCController.controllers().first {
             attachController(controller)
+        } else {
+            reconfigureMotionSources()
         }
     }
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        if let obs = prefsObserver {
+            NotificationCenter.default.removeObserver(obs)
+        }
+        deviceMotion.stopDeviceMotionUpdates()
     }
 
     // MARK: - Touch overlay (from `StreamTouchControlsContainerView`)
@@ -95,11 +117,22 @@ class StreamInput {
         if notification.object as? GCController === attachedController {
             attachedController = nil
         }
+        reconfigureMotionSources()
         mergeGamepadWithTouchAndNotify()
     }
 
     private func attachController(_ controller: GCController) {
         attachedController = controller
+        // By default iOS binds the Create/Share button to the system capture
+        // gestures (press = screenshot, long-press = recording) and swallows the
+        // presses, so the OPTIONS+SHARE menu chord could never fire from a
+        // physical controller. Claim these buttons for the stream: SHARE/OPTIONS
+        // must reach the console, and Home is the PS button.
+        if let pad = controller.extendedGamepad {
+            for button in [pad.buttonOptions, pad.buttonMenu, pad.buttonHome].compactMap({ $0 }) {
+                button.preferredSystemGestureState = .disabled
+            }
+        }
         controller.extendedGamepad?.valueChangedHandler = { [weak self] _, _ in
             self?.mergeGamepadWithTouchAndNotify()
         }
@@ -114,7 +147,60 @@ class StreamInput {
             ds.touchpadPrimary.valueChangedHandler = { _, _, _ in onChange() }
             ds.touchpadSecondary.valueChangedHandler = { _, _, _ in onChange() }
         }
+        reconfigureMotionSources()
         mergeGamepadWithTouchAndNotify()
+    }
+
+    // MARK: - Motion sources
+
+    /// True when the current MotionSource resolves to the controller's sensors.
+    private var usesControllerMotion: Bool {
+        guard attachedController?.motion != nil else { return false }
+        return motionSource == .auto || motionSource == .controller
+    }
+
+    /// True when the current MotionSource resolves to this device's sensors.
+    private var usesPhoneMotion: Bool {
+        switch motionSource {
+        case .phone: return true
+        case .auto: return attachedController?.motion == nil
+        case .controller, .off: return false
+        }
+    }
+
+    /// Start/stop the controller's and the phone's motion sensors to match the
+    /// MotionSource setting and what is currently attached. Called at init, on
+    /// controller connect/disconnect, and on preference changes (live).
+    private func reconfigureMotionSources() {
+        // Controller sensors (DualSense/DS4 need manual activation on iOS). Each
+        // sample drives a merge so the feedback stream carries continuously-live
+        // motion.
+        if let motion = attachedController?.motion {
+            if usesControllerMotion {
+                if motion.sensorsRequireManualActivation && !motion.sensorsActive {
+                    motion.sensorsActive = true
+                }
+                motion.valueChangedHandler = { [weak self] _ in self?.mergeGamepadWithTouchAndNotify() }
+            } else {
+                motion.valueChangedHandler = nil
+                if motion.sensorsRequireManualActivation && motion.sensorsActive {
+                    motion.sensorsActive = false
+                }
+            }
+        }
+
+        // Phone sensors via CoreMotion, at the controller-sensor-comparable 60Hz.
+        if usesPhoneMotion {
+            if !deviceMotion.isDeviceMotionActive && deviceMotion.isDeviceMotionAvailable {
+                deviceMotion.deviceMotionUpdateInterval = 1.0 / 60.0
+                deviceMotion.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
+                    guard motion != nil else { return }
+                    self?.mergeGamepadWithTouchAndNotify()
+                }
+            }
+        } else if deviceMotion.isDeviceMotionActive {
+            deviceMotion.stopDeviceMotionUpdates()
+        }
     }
 
     // MARK: - Merge + notify
@@ -129,6 +215,7 @@ class StreamInput {
         } else {
             clearPhysicalTouchpad()
         }
+        applyMotion(to: &gamepad, controller: controller)
         var merged = ChiakiControllerState()
         chiaki_controller_state_set_idle(&merged)
         chiaki_controller_state_or(&merged, &gamepad, &touchOverlayState)
@@ -152,12 +239,16 @@ class StreamInput {
         if ds.touchpadButton.isPressed { physicalTouchpadState.buttons |= touchpadBit }
         else { physicalTouchpadState.buttons &= ~touchpadBit }
 
-        // Finger 1 presence comes from touchpadButton.isTouched (a finger resting on
-        // the surface, distinct from a physical click).
-        updatePadFinger(present: ds.touchpadButton.isTouched, dpad: ds.touchpadPrimary, id: &padFinger1Id)
-        // Finger 2 has no dedicated touch flag; treat non-zero secondary axes as
-        // present. Only false-negative is a second finger resting exactly at center
-        // — a public-API limitation, not worked around.
+        // Finger presence: on iOS, GameController does not reliably surface the
+        // DualSense capacitive touch through touchpadButton.isTouched — it tracks
+        // the CLICK, which forced click-and-drag before swipes registered (and made
+        // a plain click unusable). Treat non-zero axes as presence (like finger 2
+        // always did), keeping isTouched as a bonus signal where it works. Only
+        // false-negative is a finger resting exactly at dead center — a public-API
+        // limitation, not worked around.
+        let pri = ds.touchpadPrimary
+        updatePadFinger(present: ds.touchpadButton.isTouched || pri.xAxis.value != 0 || pri.yAxis.value != 0,
+                        dpad: pri, id: &padFinger1Id)
         let sec = ds.touchpadSecondary
         updatePadFinger(present: sec.xAxis.value != 0 || sec.yAxis.value != 0, dpad: sec, id: &padFinger2Id)
     }
@@ -225,6 +316,59 @@ class StreamInput {
         }
     }
 
+    /// Feed the active motion source (per MotionSource) through the shared C
+    /// orientation tracker and stamp gyro/accel/orientation into `state`.
+    private func applyMotion(to state: inout ChiakiControllerState, controller: GCController?) {
+        if usesControllerMotion, let motion = controller?.motion,
+           motion.sensorsActive || !motion.sensorsRequireManualActivation {
+            // GCMotion units match chiaki: rotationRate is rad/s, acceleration is in G.
+            // Frames differ though: Apple's controller frame is Z-up (observed: at rest
+            // -(gravity) ≈ (0,0,1)) while the PS/chiaki frame is Y-up with +Z toward the
+            // player. Right-handed remap: PS(x,y,z) = Apple(x, z, -y), applied to both
+            // gyro and accel; Apple's acceleration also points along gravity while PS
+            // reports the reaction force, hence the negation.
+            let rr = motion.rotationRate
+            let aX: Double, aY: Double, aZ: Double
+            if motion.hasGravityAndUserAcceleration {
+                aX = -(motion.gravity.x + motion.userAcceleration.x)
+                aY = -(motion.gravity.y + motion.userAcceleration.y)
+                aZ = -(motion.gravity.z + motion.userAcceleration.z)
+            } else {
+                aX = -motion.acceleration.x
+                aY = -motion.acceleration.y
+                aZ = -motion.acceleration.z
+            }
+            updateOrientationTracker(
+                gyro: (Float(rr.x), Float(rr.z), Float(-rr.y)),
+                accel: (Float(aX), Float(aZ), Float(-aY))
+            )
+            chiaki_orientation_tracker_apply_to_controller_state(&orientationTracker, &state)
+        } else if usesPhoneMotion, let motion = deviceMotion.deviceMotion {
+            // This device's sensors (CoreMotion), Android-parity mapping for a phone
+            // held landscape: PS(x,y,z) = device(y, z, x). CoreMotion's portrait device
+            // frame is X right / Y toward earpiece / Z out of the screen, and its
+            // acceleration points along gravity while PS reports the reaction force,
+            // hence the negation (same as the controller path).
+            let rr = motion.rotationRate
+            let aX = -(motion.gravity.x + motion.userAcceleration.x)
+            let aY = -(motion.gravity.y + motion.userAcceleration.y)
+            let aZ = -(motion.gravity.z + motion.userAcceleration.z)
+            updateOrientationTracker(
+                gyro: (Float(rr.y), Float(rr.z), Float(rr.x)),
+                accel: (Float(aY), Float(aZ), Float(aX))
+            )
+            chiaki_orientation_tracker_apply_to_controller_state(&orientationTracker, &state)
+        }
+    }
+
+    private func updateOrientationTracker(gyro: (Float, Float, Float), accel: (Float, Float, Float)) {
+        let timestampUs = UInt32(truncatingIfNeeded: Int64(ProcessInfo.processInfo.systemUptime * 1_000_000))
+        chiaki_orientation_tracker_update(&orientationTracker,
+                                          gyro.0, gyro.1, gyro.2,
+                                          accel.0, accel.1, accel.2,
+                                          &accelZero, true, timestampUs)
+    }
+
     private func notifyIfChanged() {
         let h = stateHash()
         guard h != lastStateHash else { return }
@@ -242,6 +386,9 @@ class StreamInput {
         h = h &* 31 &+ Int(controllerState.right_y)
         h = hashTouchSlot(controllerState.touches.0, h)
         h = hashTouchSlot(controllerState.touches.1, h)
+        // sample_index increments per tracker update, so hashing it defeats the
+        // change-gate for motion-only updates (gyro aiming needs every sample).
+        h = h &* 31 &+ Int(bitPattern: UInt(truncatingIfNeeded: orientationTracker.sample_index))
         return h
     }
 

--- a/ios/Pylux/Services/StreamInput.swift
+++ b/ios/Pylux/Services/StreamInput.swift
@@ -20,6 +20,11 @@ class StreamInput {
 
     private var controllerState = ChiakiControllerState()
     private var touchOverlayState = ChiakiControllerState()
+    // Physical DualSense touchpad (click + up to two fingers). Tracked persistently
+    // because chiaki touch ids are handles that must survive across merges.
+    private var physicalTouchpadState = ChiakiControllerState()
+    private var padFinger1Id: Int8 = -1
+    private var padFinger2Id: Int8 = -1
     private weak var attachedController: GCController?
     private var lastStateHash: Int = -1
     private let swapButtons: Bool
@@ -27,12 +32,18 @@ class StreamInput {
     /// The currently attached physical controller (if any). Used by `StreamRumbleFeedback` to route haptics.
     var currentController: GCController? { attachedController ?? GCController.controllers().first }
 
+    /// True when the attached controller is a physical DualSense. Gates
+    /// `enable_dualsense`: only advertise DualSense to the console when one is
+    /// actually connected, so non-DualSense users keep classic rumble.
+    var hasDualSense: Bool { (currentController?.extendedGamepad as? GCDualSenseGamepad) != nil }
+
     // MARK: - Lifecycle
 
     init() {
         swapButtons = StreamPreferences.load().swapCrossMoon
         chiaki_controller_state_set_idle(&controllerState)
         chiaki_controller_state_set_idle(&touchOverlayState)
+        chiaki_controller_state_set_idle(&physicalTouchpadState)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(controllerDidConnect),
@@ -95,6 +106,14 @@ class StreamInput {
         controller.microGamepad?.valueChangedHandler = { [weak self] _, _ in
             self?.mergeGamepadWithTouchAndNotify()
         }
+        // DualSense touchpad elements aren't reliably covered by the extendedGamepad
+        // handler, so subscribe to them directly to drive merges on pad activity.
+        if let ds = controller.extendedGamepad as? GCDualSenseGamepad {
+            let onChange: () -> Void = { [weak self] in self?.mergeGamepadWithTouchAndNotify() }
+            ds.touchpadButton.pressedChangedHandler = { _, _, _ in onChange() }
+            ds.touchpadPrimary.valueChangedHandler = { _, _, _ in onChange() }
+            ds.touchpadSecondary.valueChangedHandler = { _, _, _ in onChange() }
+        }
         mergeGamepadWithTouchAndNotify()
     }
 
@@ -106,9 +125,64 @@ class StreamInput {
         let controller = attachedController ?? GCController.controllers().first
         if let c = controller {
             fillGamepadState(&gamepad, controller: c)
+            updatePhysicalTouchpad(c)
+        } else {
+            clearPhysicalTouchpad()
         }
-        chiaki_controller_state_or(&controllerState, &gamepad, &touchOverlayState)
+        var merged = ChiakiControllerState()
+        chiaki_controller_state_set_idle(&merged)
+        chiaki_controller_state_or(&merged, &gamepad, &touchOverlayState)
+        chiaki_controller_state_or(&controllerState, &merged, &physicalTouchpadState)
         notifyIfChanged()
+    }
+
+    // MARK: - Physical DualSense touchpad
+
+    /// Poll the physical DualSense touchpad into `physicalTouchpadState`: the pad
+    /// click -> BUTTON_TOUCHPAD (bit 14), and up to two fingers -> `touches[]`.
+    /// DS4 and non-DualSense controllers expose no touchpad through GameController,
+    /// so this is a no-op for them (physical pad unavailable — the on-screen
+    /// overlay remains the touchpad path).
+    private func updatePhysicalTouchpad(_ controller: GCController) {
+        guard let ds = controller.extendedGamepad as? GCDualSenseGamepad else {
+            clearPhysicalTouchpad()
+            return
+        }
+        let touchpadBit = UInt32(1 << 14)
+        if ds.touchpadButton.isPressed { physicalTouchpadState.buttons |= touchpadBit }
+        else { physicalTouchpadState.buttons &= ~touchpadBit }
+
+        // Finger 1 presence comes from touchpadButton.isTouched (a finger resting on
+        // the surface, distinct from a physical click).
+        updatePadFinger(present: ds.touchpadButton.isTouched, dpad: ds.touchpadPrimary, id: &padFinger1Id)
+        // Finger 2 has no dedicated touch flag; treat non-zero secondary axes as
+        // present. Only false-negative is a second finger resting exactly at center
+        // — a public-API limitation, not worked around.
+        let sec = ds.touchpadSecondary
+        updatePadFinger(present: sec.xAxis.value != 0 || sec.yAxis.value != 0, dpad: sec, id: &padFinger2Id)
+    }
+
+    private func updatePadFinger(present: Bool, dpad: GCControllerDirectionPad, id: inout Int8) {
+        if present {
+            // touchpad axes are [-1, 1]; PS touchpad space is [0, 1919] x [0, 941],
+            // y down-positive (GameController y is up-positive, so invert).
+            let x = UInt16(max(0, min(1919, Int(((dpad.xAxis.value + 1) / 2) * 1919))))
+            let y = UInt16(max(0, min(941, Int(((1 - dpad.yAxis.value) / 2) * 941))))
+            if id < 0 {
+                id = chiaki_controller_state_start_touch(&physicalTouchpadState, x, y)
+            } else {
+                chiaki_controller_state_set_touch_pos(&physicalTouchpadState, UInt8(id), x, y)
+            }
+        } else if id >= 0 {
+            chiaki_controller_state_stop_touch(&physicalTouchpadState, UInt8(id))
+            id = -1
+        }
+    }
+
+    private func clearPhysicalTouchpad() {
+        if padFinger1Id >= 0 { chiaki_controller_state_stop_touch(&physicalTouchpadState, UInt8(padFinger1Id)); padFinger1Id = -1 }
+        if padFinger2Id >= 0 { chiaki_controller_state_stop_touch(&physicalTouchpadState, UInt8(padFinger2Id)); padFinger2Id = -1 }
+        physicalTouchpadState.buttons &= ~UInt32(1 << 14)
     }
 
     private func fillGamepadState(_ state: inout ChiakiControllerState, controller: GCController) {

--- a/ios/Pylux/Services/StreamInput.swift
+++ b/ios/Pylux/Services/StreamInput.swift
@@ -85,6 +85,14 @@ class StreamInput {
             NotificationCenter.default.removeObserver(obs)
         }
         deviceMotion.stopDeviceMotionUpdates()
+        // Power down the controller's sensors too (they were manually activated);
+        // leaving them on drains a Bluetooth DualSense after the stream ends.
+        if let motion = (attachedController ?? GCController.controllers().first)?.motion {
+            motion.valueChangedHandler = nil
+            if motion.sensorsRequireManualActivation && motion.sensorsActive {
+                motion.sensorsActive = false
+            }
+        }
     }
 
     // MARK: - Touch overlay (from `StreamTouchControlsContainerView`)
@@ -155,7 +163,10 @@ class StreamInput {
 
     /// True when the current MotionSource resolves to the controller's sensors.
     private var usesControllerMotion: Bool {
-        guard attachedController?.motion != nil else { return false }
+        // Resolve against the same controller the merge uses (currentController
+        // falls back to GCController.controllers().first before the connect
+        // notification lands), so buttons and motion always agree on the source.
+        guard currentController?.motion != nil else { return false }
         return motionSource == .auto || motionSource == .controller
     }
 
@@ -163,7 +174,7 @@ class StreamInput {
     private var usesPhoneMotion: Bool {
         switch motionSource {
         case .phone: return true
-        case .auto: return attachedController?.motion == nil
+        case .auto: return currentController?.motion == nil
         case .controller, .off: return false
         }
     }
@@ -175,7 +186,7 @@ class StreamInput {
         // Controller sensors (DualSense/DS4 need manual activation on iOS). Each
         // sample drives a merge so the feedback stream carries continuously-live
         // motion.
-        if let motion = attachedController?.motion {
+        if let motion = currentController?.motion {
             if usesControllerMotion {
                 if motion.sensorsRequireManualActivation && !motion.sensorsActive {
                     motion.sensorsActive = true

--- a/ios/Pylux/Services/StreamRumbleFeedback.swift
+++ b/ios/Pylux/Services/StreamRumbleFeedback.swift
@@ -91,13 +91,15 @@ final class StreamRumbleFeedback {
         controllerWithEngine = nil
     }
 
-    func applyRumble(left: UInt8, right: UInt8, rumbleEnabled: Bool) {
+    func applyRumble(left: UInt8, right: UInt8, rumbleEnabled: Bool, intensityPercent: Int = 100) {
         if let player = player {
             try? player.stop(atTime: CHHapticTimeImmediate)
         }
         player = nil
         guard rumbleEnabled else { return }
-        let amp = min(255, (Int(left) + Int(right)) / 2)
+        // User-scalable strength (0–500%, 100 = console default), matching Android:
+        // scale the averaged motor amplitude and clamp to the 0–255 range.
+        let amp = min(255, max(0, Int(Double((Int(left) + Int(right)) / 2) * Double(intensityPercent) / 100.0)))
         guard amp > 0 else { return }
 
         let currentController = input?.currentController

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -468,15 +468,13 @@ final class StreamSession: ObservableObject {
                         cInfo.video_max_fps = connectInfo.videoMaxFps
                         cInfo.video_bitrate = connectInfo.videoBitrate
                         cInfo.video_codec = Int32(connectInfo.videoCodec)
-                        // True for Remote Play and PSCLOUD, matching Android: a Remote Play PS5
-                        // sends rumble ONLY as DualSense haptic audio (a DualShock4-declared
-                        // client gets no motor data at all), so gating this on an attached
-                        // DualSense left RP rumble silent whenever the controller enumerated
-                        // after session creation. The haptics sink below converts the haptic
-                        // audio back to normal rumble events. PSNOW (PS3 titles) is the
-                        // exception: PS3 predates every DualSense concept, so don't declare
-                        // one or request DualSense features there.
-                        cInfo.enable_dualsense = connectInfo.serviceType != 1
+                        // Always true, matching Qt and Android: a Remote Play PS5 sends rumble
+                        // ONLY as DualSense haptic audio (a DualShock4-declared client gets no
+                        // motor data at all), so gating this on an attached DualSense left RP
+                        // rumble silent whenever the controller enumerated after session
+                        // creation. The haptics sink below converts the haptic audio back to
+                        // normal rumble events. Harmless for cloud (PSNOW/PSCLOUD verified).
+                        cInfo.enable_dualsense = true
                         cInfo.holepunch_session = holepunchPtr
                         cInfo.auto_regist = connectInfo.autoRegist
                         // Cloud streaming fields (matching Android JNI)
@@ -682,9 +680,9 @@ final class StreamSession: ObservableObject {
             cInfo.video_max_fps = connectInfo.videoMaxFps
             cInfo.video_bitrate = connectInfo.videoBitrate
             cInfo.video_codec = Int32(connectInfo.videoCodec)
-            // True except for PSNOW (PS3 titles) -- see createAndStartSession; RP
-            // rumble requires it, and PS3 predates every DualSense concept.
-            cInfo.enable_dualsense = connectInfo.serviceType != 1
+            // Always true, matching Qt and Android -- see createAndStartSession
+            // (RP rumble requires it; harmless for cloud).
+            cInfo.enable_dualsense = true
             cInfo.holepunch_session = holepunchPtr
             cInfo.auto_regist = connectInfo.autoRegist
             _ = withUnsafeMutableBytes(of: &cInfo.regist_key) { buf in

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -347,83 +347,100 @@ final class StreamSession: ObservableObject {
         createAndStartSessionSync(connectInfo: connectInfo, holepunchPtr: hpPtr, hpSession: hpSession)
     }
 
-    // MARK: - Create and start native session
+    // MARK: - Session event handling
 
-    private nonisolated func createAndStartSession(connectInfo: StreamConnectInfo, holepunchPtr: UInt) async {
+    /// Single handler for every bridge session event. BOTH session-creation paths
+    /// (the async direct/cloud path and the dedicated-thread PSN path) dispatch
+    /// here — the switch used to be duplicated in each and the copies diverged
+    /// (the PSN copy was missing the PS-chord case, so the in-stream menu never
+    /// opened on PSN sessions). Do not fork this switch again.
+    private func handleSessionEvent(_ event: ChiakiSessionBridgeEvent) {
+        switch event.type.rawValue {
+        case 0: // ChiakiSessionBridgeEventConnected
+            os_log(.default, log: sessionLog, "[StreamSession] Session connected — video starting")
+            connectionPhase = ""
+            state = .connected
+            input.resendMergedControllerStateIfNeeded()
+            rumbleFeedback?.shutdown()
+            rumbleFeedback = StreamRumbleFeedback(input: input)
+            rumbleFeedback?.prepare()
+        case 16: // ChiakiSessionBridgeEventPsChord -> surface the in-stream menu
+            os_log(.default, log: sessionLog, "[StreamSession] PS chord fired -> requesting in-stream menu")
+            menuRequestToken &+= 1
+        case 8: // ChiakiSessionBridgeEventRumble
+            rumbleFeedback?.applyRumble(
+                left: event.rumble_left,
+                right: event.rumble_right,
+                rumbleEnabled: rumbleEffectsEnabled,
+                intensityPercent: Int(Float(rumbleIntensity) * consoleRumbleScale)
+            )
+        case 10: // ChiakiSessionBridgeEventTriggerEffects
+            // Mirror Qt: skip entirely when the console's trigger intensity is Off.
+            if adaptiveTriggersEnabled && consoleTriggerScale > 0 {
+                let l = withUnsafeBytes(of: event.trigger_left) { Array($0) }
+                let r = withUnsafeBytes(of: event.trigger_right) { Array($0) }
+                StreamTriggerFeedback.apply(controller: input.currentController,
+                                            typeLeft: event.trigger_type_left, left: l,
+                                            typeRight: event.trigger_type_right, right: r,
+                                            intensityScale: consoleTriggerScale)
+            }
+        case 14: // ChiakiSessionBridgeEventHapticIntensity (console setting)
+            consoleRumbleScale = Self.intensityScale(event.effect_intensity)
+        case 15: // ChiakiSessionBridgeEventTriggerIntensity (console setting)
+            consoleTriggerScale = Self.intensityScale(event.effect_intensity)
+            if consoleTriggerScale == 0 {
+                StreamTriggerFeedback.reset(controller: input.currentController)
+            }
+        case 9: // ChiakiSessionBridgeEventQuit
+            rumbleFeedback?.shutdown()
+            rumbleFeedback = nil
+            StreamTriggerFeedback.reset(controller: input.currentController)
+            let reasonStr = event.quit_reason_str.map { String(cString: $0) }
+            let quitMsg = reasonStr ?? String(format: "reason=0x%08x", event.quit_reason)
+            os_log(.error, log: sessionLog, "[StreamSession] Session quit: %{public}s", quitMsg)
+            state = .quit(reason: event.quit_reason, reasonString: reasonStr)
+        case 1: // ChiakiSessionBridgeEventLoginPinRequest
+            connectionPhase = ""
+            state = .loginPinRequest(pinIncorrect: event.login_pin_incorrect)
+        case 3: // ChiakiSessionBridgeEventRegist (auto-registration succeeded)
+            let mac = withUnsafeBytes(of: event.regist_server_mac) { Data($0) }
+            let nickname = withUnsafeBytes(of: event.regist_server_nickname) {
+                String(cString: $0.baseAddress!.assumingMemoryBound(to: CChar.self))
+            }
+            let registKey = withUnsafeBytes(of: event.regist_rp_regist_key) { Data($0) }
+            let rpKey = withUnsafeBytes(of: event.regist_rp_key) { Data($0) }
+            os_log(.default, log: sessionLog, "%{public}s", "[StreamSession] Auto-registration succeeded: \(nickname)")
+            autoRegisteredHost = RegisteredHost(
+                target: Int(event.regist_target),
+                serverMac: mac,
+                serverNickname: nickname,
+                rpRegistKey: registKey,
+                rpKeyType: Int(event.regist_rp_key_type),
+                rpKey: rpKey
+            )
+        default:
+            break
+        }
+    }
+
+    /// Shared receiver setup: copy the C event struct and hand it to
+    /// handleSessionEvent on the main actor.
+    private nonisolated func makeSessionEventReceiver() -> SessionEventReceiver {
         let receiver = SessionEventReceiver()
         receiver.eventBlock = { [weak self] eventPtr in
             guard let self = self, let eventPtr = eventPtr else { return }
             let event = eventPtr.assumingMemoryBound(to: ChiakiSessionBridgeEvent.self).pointee
-            let typeRaw = event.type.rawValue
             Task { @MainActor in
-                switch typeRaw {
-                case 0: // ChiakiSessionBridgeEventConnected
-                    os_log(.default, log: sessionLog, "[StreamSession] Session connected — video starting")
-                    self.connectionPhase = ""
-                    self.state = .connected
-                    self.input.resendMergedControllerStateIfNeeded()
-                    self.rumbleFeedback?.shutdown()
-                    self.rumbleFeedback = StreamRumbleFeedback(input: self.input)
-                    self.rumbleFeedback?.prepare()
-                case 16: // ChiakiSessionBridgeEventPsChord -> surface the in-stream menu
-                    os_log(.default, log: sessionLog, "[StreamSession] PS chord fired -> requesting in-stream menu")
-                    self.menuRequestToken &+= 1
-                case 8: // ChiakiSessionBridgeEventRumble
-                    self.rumbleFeedback?.applyRumble(
-                        left: event.rumble_left,
-                        right: event.rumble_right,
-                        rumbleEnabled: self.rumbleEffectsEnabled,
-                        intensityPercent: Int(Float(self.rumbleIntensity) * self.consoleRumbleScale)
-                    )
-                case 10: // ChiakiSessionBridgeEventTriggerEffects
-                    // Mirror Qt: skip entirely when the console's trigger intensity is Off.
-                    if self.adaptiveTriggersEnabled && self.consoleTriggerScale > 0 {
-                        let l = withUnsafeBytes(of: event.trigger_left) { Array($0) }
-                        let r = withUnsafeBytes(of: event.trigger_right) { Array($0) }
-                        StreamTriggerFeedback.apply(controller: self.input.currentController,
-                                                    typeLeft: event.trigger_type_left, left: l,
-                                                    typeRight: event.trigger_type_right, right: r,
-                                                    intensityScale: self.consoleTriggerScale)
-                    }
-                case 14: // ChiakiSessionBridgeEventHapticIntensity (console setting)
-                    self.consoleRumbleScale = Self.intensityScale(event.effect_intensity)
-                case 15: // ChiakiSessionBridgeEventTriggerIntensity (console setting)
-                    self.consoleTriggerScale = Self.intensityScale(event.effect_intensity)
-                    if self.consoleTriggerScale == 0 {
-                        StreamTriggerFeedback.reset(controller: self.input.currentController)
-                    }
-                case 9: // ChiakiSessionBridgeEventQuit
-                    self.rumbleFeedback?.shutdown()
-                    self.rumbleFeedback = nil
-                    StreamTriggerFeedback.reset(controller: self.input.currentController)
-                    let reasonStr = event.quit_reason_str.map { String(cString: $0) }
-                    let quitMsg = reasonStr ?? String(format: "reason=0x%08x", event.quit_reason)
-                    os_log(.error, log: sessionLog, "[StreamSession] Session quit: %{public}s", quitMsg)
-                    self.state = .quit(reason: event.quit_reason, reasonString: reasonStr)
-                case 1: // ChiakiSessionBridgeEventLoginPinRequest
-                    self.connectionPhase = ""
-                    self.state = .loginPinRequest(pinIncorrect: event.login_pin_incorrect)
-                case 3: // ChiakiSessionBridgeEventRegist (auto-registration succeeded)
-                    let mac = withUnsafeBytes(of: event.regist_server_mac) { Data($0) }
-                    let nickname = withUnsafeBytes(of: event.regist_server_nickname) {
-                        String(cString: $0.baseAddress!.assumingMemoryBound(to: CChar.self))
-                    }
-                    let registKey = withUnsafeBytes(of: event.regist_rp_regist_key) { Data($0) }
-                    let rpKey = withUnsafeBytes(of: event.regist_rp_key) { Data($0) }
-                    os_log(.default, log: sessionLog, "%{public}s", "[StreamSession] Auto-registration succeeded: \(nickname)")
-                    self.autoRegisteredHost = RegisteredHost(
-                        target: Int(event.regist_target),
-                        serverMac: mac,
-                        serverNickname: nickname,
-                        rpRegistKey: registKey,
-                        rpKeyType: Int(event.regist_rp_key_type),
-                        rpKey: rpKey
-                    )
-                default:
-                    break
-                }
+                self.handleSessionEvent(event)
             }
         }
+        return receiver
+    }
+
+    // MARK: - Create and start native session
+
+    private nonisolated func createAndStartSession(connectInfo: StreamConnectInfo, holepunchPtr: UInt) async {
+        let receiver = makeSessionEventReceiver()
 
         await MainActor.run { [weak self] in
             if connectInfo.isCloudConnection {
@@ -586,73 +603,7 @@ final class StreamSession: ObservableObject {
     // MARK: - Synchronous session creation for PSN connections (runs on dedicated thread)
 
     private func createAndStartSessionSync(connectInfo: StreamConnectInfo, holepunchPtr: UInt, hpSession: PyluxHolepunchSession) {
-        let receiver = SessionEventReceiver()
-        receiver.eventBlock = { [weak self] eventPtr in
-            guard let self = self, let eventPtr = eventPtr else { return }
-            let event = eventPtr.assumingMemoryBound(to: ChiakiSessionBridgeEvent.self).pointee
-            let typeRaw = event.type.rawValue
-            DispatchQueue.main.async {
-                switch typeRaw {
-                case 0:
-                    os_log(.default, log: sessionLog, "[StreamSession] Session connected (cloud) — video starting")
-                    self.connectionPhase = ""
-                    self.state = .connected
-                    self.input.resendMergedControllerStateIfNeeded()
-                    self.rumbleFeedback?.shutdown()
-                    self.rumbleFeedback = StreamRumbleFeedback(input: self.input)
-                    self.rumbleFeedback?.prepare()
-                case 8:
-                    self.rumbleFeedback?.applyRumble(
-                        left: event.rumble_left,
-                        right: event.rumble_right,
-                        rumbleEnabled: self.rumbleEffectsEnabled,
-                        intensityPercent: Int(Float(self.rumbleIntensity) * self.consoleRumbleScale)
-                    )
-                case 10: // ChiakiSessionBridgeEventTriggerEffects
-                    // Mirror Qt: skip entirely when the console's trigger intensity is Off.
-                    if self.adaptiveTriggersEnabled && self.consoleTriggerScale > 0 {
-                        let l = withUnsafeBytes(of: event.trigger_left) { Array($0) }
-                        let r = withUnsafeBytes(of: event.trigger_right) { Array($0) }
-                        StreamTriggerFeedback.apply(controller: self.input.currentController,
-                                                    typeLeft: event.trigger_type_left, left: l,
-                                                    typeRight: event.trigger_type_right, right: r,
-                                                    intensityScale: self.consoleTriggerScale)
-                    }
-                case 14: // ChiakiSessionBridgeEventHapticIntensity (console setting)
-                    self.consoleRumbleScale = Self.intensityScale(event.effect_intensity)
-                case 15: // ChiakiSessionBridgeEventTriggerIntensity (console setting)
-                    self.consoleTriggerScale = Self.intensityScale(event.effect_intensity)
-                    if self.consoleTriggerScale == 0 {
-                        StreamTriggerFeedback.reset(controller: self.input.currentController)
-                    }
-                case 9:
-                    self.rumbleFeedback?.shutdown()
-                    self.rumbleFeedback = nil
-                    StreamTriggerFeedback.reset(controller: self.input.currentController)
-                    let reasonStr = event.quit_reason_str.map { String(cString: $0) }
-                    let quitMsg = reasonStr ?? String(format: "reason=0x%08x", event.quit_reason)
-                    os_log(.error, log: sessionLog, "[StreamSession] Session quit: %{public}s", quitMsg)
-                    self.state = .quit(reason: event.quit_reason, reasonString: reasonStr)
-                case 1:
-                    self.connectionPhase = ""
-                    self.state = .loginPinRequest(pinIncorrect: event.login_pin_incorrect)
-                case 3:
-                    let mac = withUnsafeBytes(of: event.regist_server_mac) { Data($0) }
-                    let nickname = withUnsafeBytes(of: event.regist_server_nickname) {
-                        String(cString: $0.baseAddress!.assumingMemoryBound(to: CChar.self))
-                    }
-                    let registKey = withUnsafeBytes(of: event.regist_rp_regist_key) { Data($0) }
-                    let rpKey = withUnsafeBytes(of: event.regist_rp_key) { Data($0) }
-                    os_log(.default, log: sessionLog, "%{public}s", "[StreamSession] Auto-registration succeeded: \(nickname)")
-                    self.autoRegisteredHost = RegisteredHost(
-                        target: Int(event.regist_target), serverMac: mac,
-                        serverNickname: nickname, rpRegistKey: registKey,
-                        rpKeyType: Int(event.regist_rp_key_type), rpKey: rpKey
-                    )
-                default: break
-                }
-            }
-        }
+        let receiver = makeSessionEventReceiver()
 
         let decoder = PyluxVideoDecoder(
             width: Int32(connectInfo.videoWidth),

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -354,7 +354,10 @@ final class StreamSession: ObservableObject {
     /// here — the switch used to be duplicated in each and the copies diverged
     /// (the PSN copy was missing the PS-chord case, so the in-stream menu never
     /// opened on PSN sessions). Do not fork this switch again.
-    private func handleSessionEvent(_ event: ChiakiSessionBridgeEvent) {
+    /// `quitReasonStr` arrives separately because `event.quit_reason_str` is a
+    /// borrowed C pointer only valid during the callback — the receiver block
+    /// copies it into a String before hopping to the main actor.
+    private func handleSessionEvent(_ event: ChiakiSessionBridgeEvent, quitReasonStr: String?) {
         switch event.type.rawValue {
         case 0: // ChiakiSessionBridgeEventConnected
             os_log(.default, log: sessionLog, "[StreamSession] Session connected — video starting")
@@ -395,10 +398,9 @@ final class StreamSession: ObservableObject {
             rumbleFeedback?.shutdown()
             rumbleFeedback = nil
             StreamTriggerFeedback.reset(controller: input.currentController)
-            let reasonStr = event.quit_reason_str.map { String(cString: $0) }
-            let quitMsg = reasonStr ?? String(format: "reason=0x%08x", event.quit_reason)
+            let quitMsg = quitReasonStr ?? String(format: "reason=0x%08x", event.quit_reason)
             os_log(.error, log: sessionLog, "[StreamSession] Session quit: %{public}s", quitMsg)
-            state = .quit(reason: event.quit_reason, reasonString: reasonStr)
+            state = .quit(reason: event.quit_reason, reasonString: quitReasonStr)
         case 1: // ChiakiSessionBridgeEventLoginPinRequest
             connectionPhase = ""
             state = .loginPinRequest(pinIncorrect: event.login_pin_incorrect)
@@ -430,8 +432,11 @@ final class StreamSession: ObservableObject {
         receiver.eventBlock = { [weak self] eventPtr in
             guard let self = self, let eventPtr = eventPtr else { return }
             let event = eventPtr.assumingMemoryBound(to: ChiakiSessionBridgeEvent.self).pointee
+            // quit_reason_str points into memory the lib frees right after this
+            // callback returns — copy it NOW, before the async hop.
+            let quitReasonStr = event.quit_reason_str.map { String(cString: $0) }
             Task { @MainActor in
-                self.handleSessionEvent(event)
+                self.handleSessionEvent(event, quitReasonStr: quitReasonStr)
             }
         }
         return receiver

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -84,14 +84,33 @@ final class StreamSession: ObservableObject {
     private var rumbleFeedback: StreamRumbleFeedback?
     /// Cached from `StreamPreferences` (refreshed on `resume()` and `.streamPreferencesDidChange`) — avoids keychain read on every rumble packet.
     private var rumbleEffectsEnabled: Bool
+    /// Rumble strength percent (0–500, 100 = 1x), cached like `rumbleEffectsEnabled`.
+    private var rumbleIntensity: Int
+    /// Console-side DualSense intensity settings (HapticIntensity/TriggerIntensity
+    /// events), applied like Qt: rumble amplitude is scaled, trigger effects are
+    /// scaled and fully skipped when the console says Off.
+    private var consoleRumbleScale: Float = 1.0
+    private var consoleTriggerScale: Float = 1.0
+
+    /// Qt's multipliers for ChiakiDualSenseEffectIntensity (0=Off,1=Strong,2=Medium,3=Weak).
+    private static func intensityScale(_ raw: Int32) -> Float {
+        switch raw {
+        case 0: return 0
+        case 2: return 0.5
+        case 3: return 0.33
+        default: return 1.0
+        }
+    }
     private var adaptiveTriggersEnabled: Bool
     private var streamPrefsObserver: NSObjectProtocol?
 
     init(connectInfo: StreamConnectInfo, input: StreamInput) {
         self.connectInfo = connectInfo
         self.input = input
-        rumbleEffectsEnabled = StreamPreferences.load().rumbleEnabled
-        adaptiveTriggersEnabled = StreamPreferences.load().adaptiveTriggersEnabled
+        let prefs = StreamPreferences.load()
+        rumbleEffectsEnabled = prefs.rumbleEnabled
+        rumbleIntensity = prefs.rumbleIntensity
+        adaptiveTriggersEnabled = prefs.adaptiveTriggersEnabled
         input.controllerStateChangedCallback = { [weak self] statePtr in
             guard let self = self, let ref = self.sessionRef else { return }
             _ = chiaki_session_bridge_set_controller_state(ref, statePtr)
@@ -102,8 +121,10 @@ final class StreamSession: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.rumbleEffectsEnabled = StreamPreferences.load().rumbleEnabled
-                let triggers = StreamPreferences.load().adaptiveTriggersEnabled
+                let prefs = StreamPreferences.load()
+                self?.rumbleEffectsEnabled = prefs.rumbleEnabled
+                self?.rumbleIntensity = prefs.rumbleIntensity
+                let triggers = prefs.adaptiveTriggersEnabled
                 if self?.adaptiveTriggersEnabled == true && !triggers {
                     StreamTriggerFeedback.reset(controller: self?.input.currentController) // don't leave a resistance latched
                 }
@@ -120,7 +141,9 @@ final class StreamSession: ObservableObject {
 
     func resume() {
         guard state == .idle else { return }
-        rumbleEffectsEnabled = StreamPreferences.load().rumbleEnabled
+        let resumePrefs = StreamPreferences.load()
+        rumbleEffectsEnabled = resumePrefs.rumbleEnabled
+        rumbleIntensity = resumePrefs.rumbleIntensity
         state = .connecting
         if connectInfo.isPsnConnection {
             connectionPhase = "Preparing internet connection…"
@@ -327,7 +350,6 @@ final class StreamSession: ObservableObject {
     // MARK: - Create and start native session
 
     private nonisolated func createAndStartSession(connectInfo: StreamConnectInfo, holepunchPtr: UInt) async {
-        let hasDualSense = input.hasDualSense
         let receiver = SessionEventReceiver()
         receiver.eventBlock = { [weak self] eventPtr in
             guard let self = self, let eventPtr = eventPtr else { return }
@@ -350,15 +372,25 @@ final class StreamSession: ObservableObject {
                     self.rumbleFeedback?.applyRumble(
                         left: event.rumble_left,
                         right: event.rumble_right,
-                        rumbleEnabled: self.rumbleEffectsEnabled
+                        rumbleEnabled: self.rumbleEffectsEnabled,
+                        intensityPercent: Int(Float(self.rumbleIntensity) * self.consoleRumbleScale)
                     )
                 case 10: // ChiakiSessionBridgeEventTriggerEffects
-                    if self.adaptiveTriggersEnabled {
+                    // Mirror Qt: skip entirely when the console's trigger intensity is Off.
+                    if self.adaptiveTriggersEnabled && self.consoleTriggerScale > 0 {
                         let l = withUnsafeBytes(of: event.trigger_left) { Array($0) }
                         let r = withUnsafeBytes(of: event.trigger_right) { Array($0) }
                         StreamTriggerFeedback.apply(controller: self.input.currentController,
                                                     typeLeft: event.trigger_type_left, left: l,
-                                                    typeRight: event.trigger_type_right, right: r)
+                                                    typeRight: event.trigger_type_right, right: r,
+                                                    intensityScale: self.consoleTriggerScale)
+                    }
+                case 14: // ChiakiSessionBridgeEventHapticIntensity (console setting)
+                    self.consoleRumbleScale = Self.intensityScale(event.effect_intensity)
+                case 15: // ChiakiSessionBridgeEventTriggerIntensity (console setting)
+                    self.consoleTriggerScale = Self.intensityScale(event.effect_intensity)
+                    if self.consoleTriggerScale == 0 {
+                        StreamTriggerFeedback.reset(controller: self.input.currentController)
                     }
                 case 9: // ChiakiSessionBridgeEventQuit
                     self.rumbleFeedback?.shutdown()
@@ -436,7 +468,12 @@ final class StreamSession: ObservableObject {
                         cInfo.video_max_fps = connectInfo.videoMaxFps
                         cInfo.video_bitrate = connectInfo.videoBitrate
                         cInfo.video_codec = Int32(connectInfo.videoCodec)
-                        cInfo.enable_dualsense = hasDualSense // only advertise DualSense when one is attached (else the console switches to haptic-audio and classic rumble is lost)
+                        // Always true, matching Android: a Remote Play PS5 sends rumble ONLY as
+                        // DualSense haptic audio (a DualShock4-declared client gets no motor data
+                        // at all), so gating this on an attached DualSense left RP rumble silent
+                        // whenever the controller enumerated after session creation. The haptics
+                        // sink below converts the haptic audio back to normal rumble events.
+                        cInfo.enable_dualsense = true
                         cInfo.holepunch_session = holepunchPtr
                         cInfo.auto_regist = connectInfo.autoRegist
                         // Cloud streaming fields (matching Android JNI)
@@ -478,10 +515,10 @@ final class StreamSession: ObservableObject {
         }
 
         chiaki_session_bridge_set_ps_chord(ref, true, 0) // always on: safe, no user toggle
-        if hasDualSense {
-            // Console will deliver rumble as DualSense haptic-audio; convert it back to rumble.
-            chiaki_session_bridge_enable_haptics_rumble(ref)
-        }
+        // Unconditional (matching enable_dualsense above): the console delivers rumble
+        // as DualSense haptic-audio; convert it back to rumble events for whatever
+        // controller is (or later becomes) attached.
+        chiaki_session_bridge_enable_haptics_rumble(ref)
 
         await MainActor.run { [weak self] in
             self?.connectionPhase = connectInfo.isCloudConnection ? "Starting cloud stream…" : "Starting stream…"
@@ -548,7 +585,6 @@ final class StreamSession: ObservableObject {
     // MARK: - Synchronous session creation for PSN connections (runs on dedicated thread)
 
     private func createAndStartSessionSync(connectInfo: StreamConnectInfo, holepunchPtr: UInt, hpSession: PyluxHolepunchSession) {
-        let hasDualSense = input.hasDualSense
         let receiver = SessionEventReceiver()
         receiver.eventBlock = { [weak self] eventPtr in
             guard let self = self, let eventPtr = eventPtr else { return }
@@ -568,15 +604,25 @@ final class StreamSession: ObservableObject {
                     self.rumbleFeedback?.applyRumble(
                         left: event.rumble_left,
                         right: event.rumble_right,
-                        rumbleEnabled: self.rumbleEffectsEnabled
+                        rumbleEnabled: self.rumbleEffectsEnabled,
+                        intensityPercent: Int(Float(self.rumbleIntensity) * self.consoleRumbleScale)
                     )
                 case 10: // ChiakiSessionBridgeEventTriggerEffects
-                    if self.adaptiveTriggersEnabled {
+                    // Mirror Qt: skip entirely when the console's trigger intensity is Off.
+                    if self.adaptiveTriggersEnabled && self.consoleTriggerScale > 0 {
                         let l = withUnsafeBytes(of: event.trigger_left) { Array($0) }
                         let r = withUnsafeBytes(of: event.trigger_right) { Array($0) }
                         StreamTriggerFeedback.apply(controller: self.input.currentController,
                                                     typeLeft: event.trigger_type_left, left: l,
-                                                    typeRight: event.trigger_type_right, right: r)
+                                                    typeRight: event.trigger_type_right, right: r,
+                                                    intensityScale: self.consoleTriggerScale)
+                    }
+                case 14: // ChiakiSessionBridgeEventHapticIntensity (console setting)
+                    self.consoleRumbleScale = Self.intensityScale(event.effect_intensity)
+                case 15: // ChiakiSessionBridgeEventTriggerIntensity (console setting)
+                    self.consoleTriggerScale = Self.intensityScale(event.effect_intensity)
+                    if self.consoleTriggerScale == 0 {
+                        StreamTriggerFeedback.reset(controller: self.input.currentController)
                     }
                 case 9:
                     self.rumbleFeedback?.shutdown()
@@ -633,7 +679,12 @@ final class StreamSession: ObservableObject {
             cInfo.video_max_fps = connectInfo.videoMaxFps
             cInfo.video_bitrate = connectInfo.videoBitrate
             cInfo.video_codec = Int32(connectInfo.videoCodec)
-            cInfo.enable_dualsense = hasDualSense // only advertise DualSense when one is attached (else the console switches to haptic-audio and classic rumble is lost)
+            // Always true, matching Android: a Remote Play PS5 sends rumble ONLY as
+            // DualSense haptic audio (a DualShock4-declared client gets no motor data
+            // at all), so gating this on an attached DualSense left RP rumble silent
+            // whenever the controller enumerated after session creation. The haptics
+            // sink below converts the haptic audio back to normal rumble events.
+            cInfo.enable_dualsense = true
             cInfo.holepunch_session = holepunchPtr
             cInfo.auto_regist = connectInfo.autoRegist
             _ = withUnsafeMutableBytes(of: &cInfo.regist_key) { buf in
@@ -662,10 +713,10 @@ final class StreamSession: ObservableObject {
         }
 
         chiaki_session_bridge_set_ps_chord(ref, true, 0) // always on: safe, no user toggle
-        if hasDualSense {
-            // Console will deliver rumble as DualSense haptic-audio; convert it back to rumble.
-            chiaki_session_bridge_enable_haptics_rumble(ref)
-        }
+        // Unconditional (matching enable_dualsense above): the console delivers rumble
+        // as DualSense haptic-audio; convert it back to rumble events for whatever
+        // controller is (or later becomes) attached.
+        chiaki_session_bridge_enable_haptics_rumble(ref)
 
         // Native session owns holepunch pointer now
         DispatchQueue.main.async { [weak self] in

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -67,6 +67,8 @@ final class StreamSession: ObservableObject {
     @Published private(set) var connectionPhase: String = ""
     /// Published when auto-registration succeeds (caller should save to HostStore)
     @Published private(set) var autoRegisteredHost: RegisteredHost?
+    /// Bumped each time the OPTIONS+SHARE chord fires, so the view surfaces the in-stream menu.
+    @Published private(set) var menuRequestToken: Int = 0
 
     let connectInfo: StreamConnectInfo
     let input: StreamInput
@@ -341,6 +343,9 @@ final class StreamSession: ObservableObject {
                     self.rumbleFeedback?.shutdown()
                     self.rumbleFeedback = StreamRumbleFeedback(input: self.input)
                     self.rumbleFeedback?.prepare()
+                case 16: // ChiakiSessionBridgeEventPsChord -> surface the in-stream menu
+                    os_log(.default, log: sessionLog, "[StreamSession] PS chord fired -> requesting in-stream menu")
+                    self.menuRequestToken &+= 1
                 case 8: // ChiakiSessionBridgeEventRumble
                     self.rumbleFeedback?.applyRumble(
                         left: event.rumble_left,

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -468,12 +468,15 @@ final class StreamSession: ObservableObject {
                         cInfo.video_max_fps = connectInfo.videoMaxFps
                         cInfo.video_bitrate = connectInfo.videoBitrate
                         cInfo.video_codec = Int32(connectInfo.videoCodec)
-                        // Always true, matching Android: a Remote Play PS5 sends rumble ONLY as
-                        // DualSense haptic audio (a DualShock4-declared client gets no motor data
-                        // at all), so gating this on an attached DualSense left RP rumble silent
-                        // whenever the controller enumerated after session creation. The haptics
-                        // sink below converts the haptic audio back to normal rumble events.
-                        cInfo.enable_dualsense = true
+                        // True for Remote Play and PSCLOUD, matching Android: a Remote Play PS5
+                        // sends rumble ONLY as DualSense haptic audio (a DualShock4-declared
+                        // client gets no motor data at all), so gating this on an attached
+                        // DualSense left RP rumble silent whenever the controller enumerated
+                        // after session creation. The haptics sink below converts the haptic
+                        // audio back to normal rumble events. PSNOW (PS3 titles) is the
+                        // exception: PS3 predates every DualSense concept, so don't declare
+                        // one or request DualSense features there.
+                        cInfo.enable_dualsense = connectInfo.serviceType != 1
                         cInfo.holepunch_session = holepunchPtr
                         cInfo.auto_regist = connectInfo.autoRegist
                         // Cloud streaming fields (matching Android JNI)
@@ -679,12 +682,9 @@ final class StreamSession: ObservableObject {
             cInfo.video_max_fps = connectInfo.videoMaxFps
             cInfo.video_bitrate = connectInfo.videoBitrate
             cInfo.video_codec = Int32(connectInfo.videoCodec)
-            // Always true, matching Android: a Remote Play PS5 sends rumble ONLY as
-            // DualSense haptic audio (a DualShock4-declared client gets no motor data
-            // at all), so gating this on an attached DualSense left RP rumble silent
-            // whenever the controller enumerated after session creation. The haptics
-            // sink below converts the haptic audio back to normal rumble events.
-            cInfo.enable_dualsense = true
+            // True except for PSNOW (PS3 titles) -- see createAndStartSession; RP
+            // rumble requires it, and PS3 predates every DualSense concept.
+            cInfo.enable_dualsense = connectInfo.serviceType != 1
             cInfo.holepunch_session = holepunchPtr
             cInfo.auto_regist = connectInfo.autoRegist
             _ = withUnsafeMutableBytes(of: &cInfo.regist_key) { buf in

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -82,12 +82,14 @@ final class StreamSession: ObservableObject {
     private var rumbleFeedback: StreamRumbleFeedback?
     /// Cached from `StreamPreferences` (refreshed on `resume()` and `.streamPreferencesDidChange`) — avoids keychain read on every rumble packet.
     private var rumbleEffectsEnabled: Bool
+    private var adaptiveTriggersEnabled: Bool
     private var streamPrefsObserver: NSObjectProtocol?
 
     init(connectInfo: StreamConnectInfo, input: StreamInput) {
         self.connectInfo = connectInfo
         self.input = input
         rumbleEffectsEnabled = StreamPreferences.load().rumbleEnabled
+        adaptiveTriggersEnabled = StreamPreferences.load().adaptiveTriggersEnabled
         input.controllerStateChangedCallback = { [weak self] statePtr in
             guard let self = self, let ref = self.sessionRef else { return }
             _ = chiaki_session_bridge_set_controller_state(ref, statePtr)
@@ -99,6 +101,11 @@ final class StreamSession: ObservableObject {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.rumbleEffectsEnabled = StreamPreferences.load().rumbleEnabled
+                let triggers = StreamPreferences.load().adaptiveTriggersEnabled
+                if self?.adaptiveTriggersEnabled == true && !triggers {
+                    StreamTriggerFeedback.reset(controller: self?.input.currentController) // don't leave a resistance latched
+                }
+                self?.adaptiveTriggersEnabled = triggers
             }
         }
     }
@@ -318,6 +325,7 @@ final class StreamSession: ObservableObject {
     // MARK: - Create and start native session
 
     private nonisolated func createAndStartSession(connectInfo: StreamConnectInfo, holepunchPtr: UInt) async {
+        let hasDualSense = input.hasDualSense
         let receiver = SessionEventReceiver()
         receiver.eventBlock = { [weak self] eventPtr in
             guard let self = self, let eventPtr = eventPtr else { return }
@@ -339,9 +347,18 @@ final class StreamSession: ObservableObject {
                         right: event.rumble_right,
                         rumbleEnabled: self.rumbleEffectsEnabled
                     )
+                case 10: // ChiakiSessionBridgeEventTriggerEffects
+                    if self.adaptiveTriggersEnabled {
+                        let l = withUnsafeBytes(of: event.trigger_left) { Array($0) }
+                        let r = withUnsafeBytes(of: event.trigger_right) { Array($0) }
+                        StreamTriggerFeedback.apply(controller: self.input.currentController,
+                                                    typeLeft: event.trigger_type_left, left: l,
+                                                    typeRight: event.trigger_type_right, right: r)
+                    }
                 case 9: // ChiakiSessionBridgeEventQuit
                     self.rumbleFeedback?.shutdown()
                     self.rumbleFeedback = nil
+                    StreamTriggerFeedback.reset(controller: self.input.currentController)
                     let reasonStr = event.quit_reason_str.map { String(cString: $0) }
                     let quitMsg = reasonStr ?? String(format: "reason=0x%08x", event.quit_reason)
                     os_log(.error, log: sessionLog, "[StreamSession] Session quit: %{public}s", quitMsg)
@@ -414,6 +431,7 @@ final class StreamSession: ObservableObject {
                         cInfo.video_max_fps = connectInfo.videoMaxFps
                         cInfo.video_bitrate = connectInfo.videoBitrate
                         cInfo.video_codec = Int32(connectInfo.videoCodec)
+                        cInfo.enable_dualsense = hasDualSense // only advertise DualSense when one is attached (else the console switches to haptic-audio and classic rumble is lost)
                         cInfo.holepunch_session = holepunchPtr
                         cInfo.auto_regist = connectInfo.autoRegist
                         // Cloud streaming fields (matching Android JNI)
@@ -452,6 +470,12 @@ final class StreamSession: ObservableObject {
                 self?.state = .createError(errorCode: capturedErr != 0 ? capturedErr : 1, message: nil)
             }
             return
+        }
+
+        chiaki_session_bridge_set_ps_chord(ref, true, 0) // always on: safe, no user toggle
+        if hasDualSense {
+            // Console will deliver rumble as DualSense haptic-audio; convert it back to rumble.
+            chiaki_session_bridge_enable_haptics_rumble(ref)
         }
 
         await MainActor.run { [weak self] in
@@ -519,6 +543,7 @@ final class StreamSession: ObservableObject {
     // MARK: - Synchronous session creation for PSN connections (runs on dedicated thread)
 
     private func createAndStartSessionSync(connectInfo: StreamConnectInfo, holepunchPtr: UInt, hpSession: PyluxHolepunchSession) {
+        let hasDualSense = input.hasDualSense
         let receiver = SessionEventReceiver()
         receiver.eventBlock = { [weak self] eventPtr in
             guard let self = self, let eventPtr = eventPtr else { return }
@@ -540,9 +565,18 @@ final class StreamSession: ObservableObject {
                         right: event.rumble_right,
                         rumbleEnabled: self.rumbleEffectsEnabled
                     )
+                case 10: // ChiakiSessionBridgeEventTriggerEffects
+                    if self.adaptiveTriggersEnabled {
+                        let l = withUnsafeBytes(of: event.trigger_left) { Array($0) }
+                        let r = withUnsafeBytes(of: event.trigger_right) { Array($0) }
+                        StreamTriggerFeedback.apply(controller: self.input.currentController,
+                                                    typeLeft: event.trigger_type_left, left: l,
+                                                    typeRight: event.trigger_type_right, right: r)
+                    }
                 case 9:
                     self.rumbleFeedback?.shutdown()
                     self.rumbleFeedback = nil
+                    StreamTriggerFeedback.reset(controller: self.input.currentController)
                     let reasonStr = event.quit_reason_str.map { String(cString: $0) }
                     let quitMsg = reasonStr ?? String(format: "reason=0x%08x", event.quit_reason)
                     os_log(.error, log: sessionLog, "[StreamSession] Session quit: %{public}s", quitMsg)
@@ -594,6 +628,7 @@ final class StreamSession: ObservableObject {
             cInfo.video_max_fps = connectInfo.videoMaxFps
             cInfo.video_bitrate = connectInfo.videoBitrate
             cInfo.video_codec = Int32(connectInfo.videoCodec)
+            cInfo.enable_dualsense = hasDualSense // only advertise DualSense when one is attached (else the console switches to haptic-audio and classic rumble is lost)
             cInfo.holepunch_session = holepunchPtr
             cInfo.auto_regist = connectInfo.autoRegist
             _ = withUnsafeMutableBytes(of: &cInfo.regist_key) { buf in
@@ -619,6 +654,12 @@ final class StreamSession: ObservableObject {
                 self?.state = .createError(errorCode: err != 0 ? err : 1, message: nil)
             }
             return
+        }
+
+        chiaki_session_bridge_set_ps_chord(ref, true, 0) // always on: safe, no user toggle
+        if hasDualSense {
+            // Console will deliver rumble as DualSense haptic-audio; convert it back to rumble.
+            chiaki_session_bridge_enable_haptics_rumble(ref)
         }
 
         // Native session owns holepunch pointer now

--- a/ios/Pylux/Services/StreamTriggerFeedback.swift
+++ b/ios/Pylux/Services/StreamTriggerFeedback.swift
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+// Drives a physical DualSense's adaptive triggers from the console's
+// CHIAKI_EVENT_TRIGGER_EFFECTS stream data via Apple's GameController API.
+
+import Foundation
+import GameController
+
+/// Translates the PS5's raw trigger-effect descriptors (a mode byte + 10 param
+/// bytes per trigger, exactly as the DualSense HID output report carries them)
+/// into `GCDualSenseAdaptiveTrigger` semantic calls.
+///
+/// This is a per-platform translation on purpose: Apple's API is semantic
+/// (`setModeFeedback/Weapon/Vibration/…`), not raw-byte, so there is no shared-C
+/// encoder to reuse — the console's byte layout is decoded here. Effect modes the
+/// public API cannot express fall back to `setModeOff` (documented, not hacked).
+enum StreamTriggerFeedback {
+    /// PS5 DualSense trigger effect type ids (subset the firmware emits).
+    private enum EffectType {
+        static let off: UInt8 = 0x00
+        static let feedback: UInt8 = 0x01     // constant resistance from a start position
+        static let weapon: UInt8 = 0x02       // resistance between start/end that snaps back
+        static let vibration: UInt8 = 0x06    // vibrate from a start position
+        static let off2: UInt8 = 0x05         // some titles send 0x05 as "clear"
+    }
+
+    static func apply(controller: GCController?,
+                      typeLeft: UInt8, left: [UInt8],
+                      typeRight: UInt8, right: [UInt8]) {
+        guard let ds = controller?.extendedGamepad as? GCDualSenseGamepad else { return }
+        applyOne(ds.leftTrigger, type: typeLeft, params: left)
+        applyOne(ds.rightTrigger, type: typeRight, params: right)
+    }
+
+    /// Release both triggers to their neutral state. Call on session quit and when
+    /// adaptive triggers are disabled, so a resistance effect can't latch stiff.
+    static func reset(controller: GCController?) {
+        guard let ds = controller?.extendedGamepad as? GCDualSenseGamepad else { return }
+        ds.leftTrigger.setModeOff()
+        ds.rightTrigger.setModeOff()
+    }
+
+    private static func norm(_ b: UInt8) -> Float { Float(b) / 255.0 }
+
+    private static func applyOne(_ trigger: GCDualSenseAdaptiveTrigger, type: UInt8, params: [UInt8]) {
+        // params are the raw DS5 bytes; interpretation is per effect type. We map
+        // the common cases to Apple's semantic API and clear anything else.
+        // Note: the single-float mode setters import into Swift with the leading
+        // "With<FirstArg>" kept in the base name (no NS_SWIFT_NAME on these ObjC
+        // selectors), hence setModeFeedbackWithStartPosition(_:resistiveStrength:) etc.
+        switch type {
+        case EffectType.feedback:
+            // byte 0 = start position, byte 1 = resistive strength
+            trigger.setModeFeedbackWithStartPosition(norm(params.count > 0 ? params[0] : 0),
+                                                     resistiveStrength: norm(params.count > 1 ? params[1] : 0))
+        case EffectType.weapon:
+            // byte 0 = start, byte 1 = end, byte 2 = strength
+            let start = norm(params.count > 0 ? params[0] : 0)
+            var end = norm(params.count > 1 ? params[1] : 0)
+            if end <= start { end = min(1.0, start + 0.1) } // Apple requires end > start
+            trigger.setModeWeaponWithStartPosition(start, endPosition: end,
+                                                   resistiveStrength: norm(params.count > 2 ? params[2] : 0))
+        case EffectType.vibration:
+            // byte 0 = start, byte 1 = amplitude, byte 2 = frequency
+            trigger.setModeVibrationWithStartPosition(norm(params.count > 0 ? params[0] : 0),
+                                                      amplitude: norm(params.count > 1 ? params[1] : 0),
+                                                      frequency: norm(params.count > 2 ? params[2] : 0))
+        case EffectType.off, EffectType.off2:
+            trigger.setModeOff()
+        default:
+            // Multi-zone / positional-resistance curves and any unknown type are not
+            // expressible through the public semantic API here — clear rather than
+            // approximate incorrectly.
+            trigger.setModeOff()
+        }
+    }
+}

--- a/ios/Pylux/Services/StreamTriggerFeedback.swift
+++ b/ios/Pylux/Services/StreamTriggerFeedback.swift
@@ -14,21 +14,31 @@ import GameController
 /// encoder to reuse — the console's byte layout is decoded here. Effect modes the
 /// public API cannot express fall back to `setModeOff` (documented, not hacked).
 enum StreamTriggerFeedback {
-    /// PS5 DualSense trigger effect type ids (subset the firmware emits).
+    /// PS5 DualSense trigger effect type ids (as carried in the DS HID output report).
     private enum EffectType {
         static let off: UInt8 = 0x00
-        static let feedback: UInt8 = 0x01     // constant resistance from a start position
-        static let weapon: UInt8 = 0x02       // resistance between start/end that snaps back
-        static let vibration: UInt8 = 0x06    // vibrate from a start position
-        static let off2: UInt8 = 0x05         // some titles send 0x05 as "clear"
+        static let simpleFeedback: UInt8 = 0x01   // constant resistance from a start position
+        static let simpleWeapon: UInt8 = 0x02     // resistance between start/end that snaps back
+        static let off2: UInt8 = 0x05             // some titles send 0x05 as "clear"
+        static let simpleVibration: UInt8 = 0x06  // vibrate from a start position
+        static let feedback: UInt8 = 0x21         // per-zone resistance (10 zones, 3-bit strengths)
+        static let bow: UInt8 = 0x22              // tension between two positions with snap
+        static let galloping: UInt8 = 0x23        // periodic pulses between two positions
+        static let weapon: UInt8 = 0x25           // trigger-pull resistance between two zones
+        static let vibration: UInt8 = 0x26        // per-zone vibration + frequency ("automatic gun")
+        static let machine: UInt8 = 0x27          // sustained mechanical vibration
     }
 
+    /// intensityScale mirrors the console's Trigger Effect Intensity setting
+    /// (Qt folds the equivalent attenuation byte into the raw HID report; here it
+    /// scales the semantic strengths/amplitudes).
     static func apply(controller: GCController?,
                       typeLeft: UInt8, left: [UInt8],
-                      typeRight: UInt8, right: [UInt8]) {
+                      typeRight: UInt8, right: [UInt8],
+                      intensityScale: Float = 1.0) {
         guard let ds = controller?.extendedGamepad as? GCDualSenseGamepad else { return }
-        applyOne(ds.leftTrigger, type: typeLeft, params: left)
-        applyOne(ds.rightTrigger, type: typeRight, params: right)
+        applyOne(ds.leftTrigger, type: typeLeft, params: left, scale: intensityScale)
+        applyOne(ds.rightTrigger, type: typeRight, params: right, scale: intensityScale)
     }
 
     /// Release both triggers to their neutral state. Call on session quit and when
@@ -40,36 +50,105 @@ enum StreamTriggerFeedback {
     }
 
     private static func norm(_ b: UInt8) -> Float { Float(b) / 255.0 }
+    private static func byte(_ p: [UInt8], _ i: Int) -> UInt8 { i < p.count ? p[i] : 0 }
 
-    private static func applyOne(_ trigger: GCDualSenseAdaptiveTrigger, type: UInt8, params: [UInt8]) {
-        // params are the raw DS5 bytes; interpretation is per effect type. We map
-        // the common cases to Apple's semantic API and clear anything else.
+    /// The extended (0x2x) modes address 10 trigger-travel zones through a 10-bit
+    /// mask in params[0..1]. Returns the first/last active zone as normalized
+    /// trigger positions (0...1), or nil when no zone is set.
+    private static func zoneSpan(_ p: [UInt8]) -> (start: Float, end: Float)? {
+        let mask = UInt16(byte(p, 0)) | (UInt16(byte(p, 1)) << 8)
+        guard mask != 0 else { return nil }
+        var first = -1, last = -1
+        for i in 0..<10 where mask & (1 << i) != 0 {
+            if first < 0 { first = i }
+            last = i
+        }
+        return (Float(first) / 9.0, Float(last) / 9.0)
+    }
+
+    /// Extended feedback/vibration modes pack per-zone 3-bit magnitudes after the
+    /// zone mask; take the strongest zone as the single magnitude Apple's API takes.
+    private static func maxPackedMagnitude(_ p: [UInt8], from firstByte: Int) -> Float {
+        var maxVal: UInt32 = 0
+        var bits: UInt32 = 0
+        var acc: UInt32 = 0
+        for i in firstByte..<min(p.count, firstByte + 4) {
+            acc |= UInt32(p[i]) << bits
+            bits += 8
+            while bits >= 3 {
+                maxVal = max(maxVal, acc & 0x7)
+                acc >>= 3
+                bits -= 3
+            }
+        }
+        return maxVal == 0 ? 0 : Float(maxVal) / 7.0
+    }
+
+    private static func applyOne(_ trigger: GCDualSenseAdaptiveTrigger, type: UInt8, params: [UInt8], scale: Float) {
+        func scaled(_ v: Float) -> Float { min(1.0, v * max(0, scale)) }
+        // params are the raw DS5 bytes; interpretation is per effect type. Apple's
+        // API is semantic (no raw HID pass-through on iOS, unlike SDL on desktop),
+        // so the extended modes are approximated with the closest expressible
+        // effect rather than dropped.
         // Note: the single-float mode setters import into Swift with the leading
         // "With<FirstArg>" kept in the base name (no NS_SWIFT_NAME on these ObjC
         // selectors), hence setModeFeedbackWithStartPosition(_:resistiveStrength:) etc.
         switch type {
-        case EffectType.feedback:
+        case EffectType.simpleFeedback:
             // byte 0 = start position, byte 1 = resistive strength
-            trigger.setModeFeedbackWithStartPosition(norm(params.count > 0 ? params[0] : 0),
-                                                     resistiveStrength: norm(params.count > 1 ? params[1] : 0))
-        case EffectType.weapon:
+            let strength = norm(byte(params, 1))
+            guard scaled(strength) > 0 else { trigger.setModeOff(); return }
+            trigger.setModeFeedbackWithStartPosition(norm(byte(params, 0)),
+                                                     resistiveStrength: scaled(strength))
+        case EffectType.simpleWeapon:
             // byte 0 = start, byte 1 = end, byte 2 = strength
-            let start = norm(params.count > 0 ? params[0] : 0)
-            var end = norm(params.count > 1 ? params[1] : 0)
+            let start = norm(byte(params, 0))
+            var end = norm(byte(params, 1))
             if end <= start { end = min(1.0, start + 0.1) } // Apple requires end > start
+            let strength = norm(byte(params, 2))
+            guard scaled(strength) > 0 else { trigger.setModeOff(); return }
             trigger.setModeWeaponWithStartPosition(start, endPosition: end,
-                                                   resistiveStrength: norm(params.count > 2 ? params[2] : 0))
-        case EffectType.vibration:
+                                                   resistiveStrength: scaled(strength))
+        case EffectType.simpleVibration:
             // byte 0 = start, byte 1 = amplitude, byte 2 = frequency
-            trigger.setModeVibrationWithStartPosition(norm(params.count > 0 ? params[0] : 0),
-                                                      amplitude: norm(params.count > 1 ? params[1] : 0),
-                                                      frequency: norm(params.count > 2 ? params[2] : 0))
+            let amplitude = norm(byte(params, 1))
+            guard scaled(amplitude) > 0 else { trigger.setModeOff(); return }
+            trigger.setModeVibrationWithStartPosition(norm(byte(params, 0)),
+                                                      amplitude: scaled(amplitude),
+                                                      frequency: max(0.05, norm(byte(params, 2))))
+        case EffectType.feedback:
+            // zone mask + packed 3-bit per-zone strengths -> constant resistance
+            // from the first active zone at the strongest zone's strength.
+            guard let span = zoneSpan(params) else { trigger.setModeOff(); return }
+            let strength = maxPackedMagnitude(params, from: 2)
+            guard scaled(strength) > 0 else { trigger.setModeOff(); return }
+            trigger.setModeFeedbackWithStartPosition(span.start, resistiveStrength: scaled(strength))
+        case EffectType.weapon, EffectType.bow:
+            // two active zones (start/end) + 3-bit strength -> weapon resistance.
+            guard let span = zoneSpan(params) else { trigger.setModeOff(); return }
+            var end = span.end
+            if end <= span.start { end = min(1.0, span.start + 0.1) }
+            let strength = Float(byte(params, 2) & 0x7) / 7.0
+            guard scaled(strength) > 0 else { trigger.setModeOff(); return }
+            trigger.setModeWeaponWithStartPosition(span.start, endPosition: end,
+                                                   resistiveStrength: scaled(strength))
+        case EffectType.vibration, EffectType.galloping, EffectType.machine:
+            // zone mask + per-zone amplitudes, frequency in the tail byte.
+            guard let span = zoneSpan(params) else { trigger.setModeOff(); return }
+            let amplitude = maxPackedMagnitude(params, from: 2)
+            // A zero amplitude means the game wants the effect engaged but silent —
+            // switch off instead of buzzing at an invented floor.
+            guard scaled(amplitude) > 0 else { trigger.setModeOff(); return }
+            // Frequency (Hz-ish byte) observed at offset 8 in on-device captures
+            // (offset 9 as fallback); bytes 2..6 are the packed per-zone amplitudes.
+            let freqByte = byte(params, 8) != 0 ? byte(params, 8) : byte(params, 9)
+            trigger.setModeVibrationWithStartPosition(span.start,
+                                                      amplitude: scaled(amplitude),
+                                                      frequency: max(0.08, norm(freqByte)))
         case EffectType.off, EffectType.off2:
             trigger.setModeOff()
         default:
-            // Multi-zone / positional-resistance curves and any unknown type are not
-            // expressible through the public semantic API here — clear rather than
-            // approximate incorrectly.
+            // Unknown/calibration modes: clear rather than approximate incorrectly.
             trigger.setModeOff()
         }
     }

--- a/ios/Pylux/Views/SettingsView.swift
+++ b/ios/Pylux/Views/SettingsView.swift
@@ -52,6 +52,23 @@ let kCloudResolutionsPsnow: [(label: String, value: String, width: Int, height: 
     ("1080p (1920x1080)", "1080", 1920, 1080),
 ]
 
+/// Where the motion data (gyro/accel/orientation) streamed to the console comes from.
+enum MotionSource: String, Codable, CaseIterable, Identifiable {
+    case auto        // controller when it has sensors, else this device
+    case controller  // controller only
+    case phone       // this device only
+    case off         // no motion
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .auto: return "Auto (controller, fall back to phone)"
+        case .controller: return "Controller only"
+        case .phone: return "Phone only"
+        case .off: return "Off"
+        }
+    }
+}
+
 struct StreamPreferences: Codable {
     // Remote Play
     var resolutionIndex: Int = 2       // default 720p (index 2 in updated array, matches Android)
@@ -62,7 +79,9 @@ struct StreamPreferences: Codable {
     // General
     var swapCrossMoon: Bool = false
     var rumbleEnabled: Bool = true      // matches Android default true
-    var motionEnabled: Bool = true      // matches Android default true
+    /// Rumble strength percent, 0–500 (100 = 1x). Matches Android's rumbleIntensity.
+    var rumbleIntensity: Int = 100
+    var motionSource: MotionSource = .auto
     var touchHapticsEnabled: Bool = true // matches Android default true
     var adaptiveTriggersEnabled: Bool = true // DualSense adaptive triggers (physical DualSense only)
     var logVerbose: Bool = false
@@ -94,7 +113,8 @@ struct StreamPreferences: Codable {
 
     private enum CodingKeys: String, CodingKey {
         case resolutionIndex, fps, bitrate, codec
-        case swapCrossMoon, rumbleEnabled, motionEnabled, touchHapticsEnabled, logVerbose
+        case swapCrossMoon, rumbleEnabled, rumbleIntensity, motionSource, touchHapticsEnabled, logVerbose
+        case motionEnabled // legacy bool, migrated into motionSource
         case adaptiveTriggersEnabled
         case onScreenControlsEnabled, touchpadOnlyEnabled
         case cloudResolutionPscloud, cloudDatacenterPscloud, cloudBitratePscloud
@@ -110,7 +130,8 @@ struct StreamPreferences: Codable {
         codec: Int = 1,
         swapCrossMoon: Bool = false,
         rumbleEnabled: Bool = true,
-        motionEnabled: Bool = true,
+        rumbleIntensity: Int = 100,
+        motionSource: MotionSource = .auto,
         touchHapticsEnabled: Bool = true,
         logVerbose: Bool = false,
         onScreenControlsEnabled: Bool = true,
@@ -129,7 +150,8 @@ struct StreamPreferences: Codable {
         self.codec = codec
         self.swapCrossMoon = swapCrossMoon
         self.rumbleEnabled = rumbleEnabled
-        self.motionEnabled = motionEnabled
+        self.rumbleIntensity = Self.clampRumbleIntensity(rumbleIntensity)
+        self.motionSource = motionSource
         self.touchHapticsEnabled = touchHapticsEnabled
         self.logVerbose = logVerbose
         self.onScreenControlsEnabled = onScreenControlsEnabled
@@ -151,7 +173,16 @@ struct StreamPreferences: Codable {
         codec = try c.decodeIfPresent(Int.self, forKey: .codec) ?? 1
         swapCrossMoon = try c.decodeIfPresent(Bool.self, forKey: .swapCrossMoon) ?? false
         rumbleEnabled = try c.decodeIfPresent(Bool.self, forKey: .rumbleEnabled) ?? true
-        motionEnabled = try c.decodeIfPresent(Bool.self, forKey: .motionEnabled) ?? true
+        rumbleIntensity = Self.clampRumbleIntensity(
+            try c.decodeIfPresent(Int.self, forKey: .rumbleIntensity) ?? 100
+        )
+        if let source = try c.decodeIfPresent(MotionSource.self, forKey: .motionSource) {
+            motionSource = source
+        } else {
+            // Migrate the legacy motionEnabled bool (Off keeps motion off; anything else = Auto).
+            let legacy = try c.decodeIfPresent(Bool.self, forKey: .motionEnabled) ?? true
+            motionSource = legacy ? .auto : .off
+        }
         touchHapticsEnabled = try c.decodeIfPresent(Bool.self, forKey: .touchHapticsEnabled) ?? true
         adaptiveTriggersEnabled = try c.decodeIfPresent(Bool.self, forKey: .adaptiveTriggersEnabled) ?? true
         logVerbose = try c.decodeIfPresent(Bool.self, forKey: .logVerbose) ?? false
@@ -179,7 +210,8 @@ struct StreamPreferences: Codable {
         try c.encode(codec, forKey: .codec)
         try c.encode(swapCrossMoon, forKey: .swapCrossMoon)
         try c.encode(rumbleEnabled, forKey: .rumbleEnabled)
-        try c.encode(motionEnabled, forKey: .motionEnabled)
+        try c.encode(rumbleIntensity, forKey: .rumbleIntensity)
+        try c.encode(motionSource, forKey: .motionSource)
         try c.encode(touchHapticsEnabled, forKey: .touchHapticsEnabled)
         try c.encode(adaptiveTriggersEnabled, forKey: .adaptiveTriggersEnabled)
         try c.encode(logVerbose, forKey: .logVerbose)
@@ -192,6 +224,10 @@ struct StreamPreferences: Codable {
         try c.encode(cloudDatacenterPsnow, forKey: .cloudDatacenterPsnow)
         try c.encode(cloudBitratePsnow, forKey: .cloudBitratePsnow)
         try c.encode(cloudGameLanguage, forKey: .cloudGameLanguage)
+    }
+
+    static func clampRumbleIntensity(_ percent: Int) -> Int {
+        min(500, max(0, percent))
     }
 
     static func clampCloudBitrateKbps(_ kbps: Int) -> Int {
@@ -391,56 +427,94 @@ struct SettingsView: View {
             }
 
             // Swap Cross/Moon (wired)
-            VStack(alignment: .leading, spacing: 2) {
-                Toggle("Swap Cross/Moon and Box/Pyramid Buttons", isOn: $prefs.swapCrossMoon)
-                    .onChange(of: prefs.swapCrossMoon) { _ in prefs.save() }
-                Text("Swap face buttons if default mapping is incorrect (e.g. for 8BitDo controllers)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: 2) {
-                Toggle("Rumble", isOn: $prefs.rumbleEnabled)
-                    .onChange(of: prefs.rumbleEnabled) { _ in prefs.save() }
-                Text("Play console rumble on this device (Core Haptics on supported iPhones; legacy vibrate otherwise)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            VStack(alignment: .leading, spacing: 2) {
-                Toggle("Adaptive Triggers", isOn: $prefs.adaptiveTriggersEnabled)
-                    .onChange(of: prefs.adaptiveTriggersEnabled) { _ in prefs.save() }
-                Text("DualSense adaptive-trigger resistance (physical DualSense only)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            if showWorkInProgressGeneralSettings {
+            Toggle(isOn: $prefs.swapCrossMoon) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Toggle("Motion", isOn: $prefs.motionEnabled)
-                        .onChange(of: prefs.motionEnabled) { _ in prefs.save() }
-                    Text("Use device's motion sensors for controller motion")
+                    Text("Swap Cross/Moon and Box/Pyramid Buttons")
+                    Text("Swap face buttons if default mapping is incorrect (e.g. for 8BitDo controllers)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .onChange(of: prefs.swapCrossMoon) { _ in prefs.save() }
+
+            Toggle(isOn: $prefs.rumbleEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Rumble")
+                    Text("Play console rumble on this device (Core Haptics on supported iPhones; legacy vibrate otherwise)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .onChange(of: prefs.rumbleEnabled) { _ in prefs.save() }
+
+            if prefs.rumbleEnabled {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack {
+                        Text("Rumble Intensity")
+                        Spacer()
+                        Text("\(prefs.rumbleIntensity)%")
+                            .foregroundColor(.secondary)
+                            .monospacedDigit()
+                    }
+                    Slider(
+                        value: Binding(
+                            get: { Double(prefs.rumbleIntensity) },
+                            set: { prefs.rumbleIntensity = StreamPreferences.clampRumbleIntensity(Int($0.rounded())) }
+                        ),
+                        in: 0...500,
+                        step: 10,
+                        onEditingChanged: { editing in if !editing { prefs.save() } }
+                    )
+                    Text("Scales vibration strength; 100% matches the console")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
             }
 
-            VStack(alignment: .leading, spacing: 2) {
-                Toggle("Touch Haptics", isOn: $prefs.touchHapticsEnabled)
-                    .onChange(of: prefs.touchHapticsEnabled) { _ in prefs.save() }
-                Text("Light haptic feedback when using on-screen controls")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-
-            if showWorkInProgressGeneralSettings {
+            Toggle(isOn: $prefs.adaptiveTriggersEnabled) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Toggle("Verbose Logging", isOn: $prefs.logVerbose)
-                        .onChange(of: prefs.logVerbose) { _ in prefs.save() }
-                    Text("Warning: This logs a LOT! Don't enable for regular use.")
+                    Text("Adaptive Triggers")
+                    Text("DualSense adaptive-trigger resistance (physical DualSense only)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
+            }
+            .onChange(of: prefs.adaptiveTriggersEnabled) { _ in prefs.save() }
+
+            Picker(selection: $prefs.motionSource) {
+                ForEach(MotionSource.allCases) { source in
+                    Text(source.label).tag(source)
+                }
+            } label: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Gyro / Motion")
+                    Text("Motion sensors sent to the console for gyro aiming")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .onChange(of: prefs.motionSource) { _ in prefs.save() }
+
+            Toggle(isOn: $prefs.touchHapticsEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Touch Haptics")
+                    Text("Light haptic feedback when using on-screen controls")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .onChange(of: prefs.touchHapticsEnabled) { _ in prefs.save() }
+
+            if showWorkInProgressGeneralSettings {
+                Toggle(isOn: $prefs.logVerbose) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Verbose Logging")
+                        Text("Warning: This logs a LOT! Don't enable for regular use.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .onChange(of: prefs.logVerbose) { _ in prefs.save() }
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Session Logs")

--- a/ios/Pylux/Views/SettingsView.swift
+++ b/ios/Pylux/Views/SettingsView.swift
@@ -64,6 +64,7 @@ struct StreamPreferences: Codable {
     var rumbleEnabled: Bool = true      // matches Android default true
     var motionEnabled: Bool = true      // matches Android default true
     var touchHapticsEnabled: Bool = true // matches Android default true
+    var adaptiveTriggersEnabled: Bool = true // DualSense adaptive triggers (physical DualSense only)
     var logVerbose: Bool = false
 
     /// Stream overlay: full on-screen controls (matches Android `onScreenControlsEnabled`, default true)
@@ -94,6 +95,7 @@ struct StreamPreferences: Codable {
     private enum CodingKeys: String, CodingKey {
         case resolutionIndex, fps, bitrate, codec
         case swapCrossMoon, rumbleEnabled, motionEnabled, touchHapticsEnabled, logVerbose
+        case adaptiveTriggersEnabled
         case onScreenControlsEnabled, touchpadOnlyEnabled
         case cloudResolutionPscloud, cloudDatacenterPscloud, cloudBitratePscloud
         case cloudResolutionPsnow, cloudDatacenterPsnow, cloudBitratePsnow
@@ -151,6 +153,7 @@ struct StreamPreferences: Codable {
         rumbleEnabled = try c.decodeIfPresent(Bool.self, forKey: .rumbleEnabled) ?? true
         motionEnabled = try c.decodeIfPresent(Bool.self, forKey: .motionEnabled) ?? true
         touchHapticsEnabled = try c.decodeIfPresent(Bool.self, forKey: .touchHapticsEnabled) ?? true
+        adaptiveTriggersEnabled = try c.decodeIfPresent(Bool.self, forKey: .adaptiveTriggersEnabled) ?? true
         logVerbose = try c.decodeIfPresent(Bool.self, forKey: .logVerbose) ?? false
         onScreenControlsEnabled = try c.decodeIfPresent(Bool.self, forKey: .onScreenControlsEnabled) ?? true
         touchpadOnlyEnabled = try c.decodeIfPresent(Bool.self, forKey: .touchpadOnlyEnabled) ?? false
@@ -178,6 +181,7 @@ struct StreamPreferences: Codable {
         try c.encode(rumbleEnabled, forKey: .rumbleEnabled)
         try c.encode(motionEnabled, forKey: .motionEnabled)
         try c.encode(touchHapticsEnabled, forKey: .touchHapticsEnabled)
+        try c.encode(adaptiveTriggersEnabled, forKey: .adaptiveTriggersEnabled)
         try c.encode(logVerbose, forKey: .logVerbose)
         try c.encode(onScreenControlsEnabled, forKey: .onScreenControlsEnabled)
         try c.encode(touchpadOnlyEnabled, forKey: .touchpadOnlyEnabled)
@@ -399,6 +403,14 @@ struct SettingsView: View {
                 Toggle("Rumble", isOn: $prefs.rumbleEnabled)
                     .onChange(of: prefs.rumbleEnabled) { _ in prefs.save() }
                 Text("Play console rumble on this device (Core Haptics on supported iPhones; legacy vibrate otherwise)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Toggle("Adaptive Triggers", isOn: $prefs.adaptiveTriggersEnabled)
+                    .onChange(of: prefs.adaptiveTriggersEnabled) { _ in prefs.save() }
+                Text("DualSense adaptive-trigger resistance (physical DualSense only)")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/ios/Pylux/Views/StreamView.swift
+++ b/ios/Pylux/Views/StreamView.swift
@@ -367,14 +367,20 @@ struct StreamView: View {
                 )
             }
 
-            // Disconnect button (matches Android's disconnectButton)
-            Button("Disconnect") {
+            // Disconnect button (matches Android's disconnectButton). The bar is
+            // crowded (toggles + display modes + PiP), so keep the label on one
+            // line and let it scale down instead of wrapping ("Disconn/ect").
+            Button {
                 session.pause()
                 dismiss()
+            } label: {
+                Text("Disconnect")
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
             }
-            .font(.system(size: 14, weight: .medium))
+            .font(.system(size: 13, weight: .medium))
             .foregroundColor(.white)
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)

--- a/ios/Pylux/Views/StreamView.swift
+++ b/ios/Pylux/Views/StreamView.swift
@@ -246,6 +246,11 @@ struct StreamView: View {
         .sheet(isPresented: $donationCoordinator.showPaywall) {
             DonationPaywallView()
         }
+        .onChange(of: session.menuRequestToken) { _ in
+            // OPTIONS+SHARE chord fired -> surface the in-stream menu (auto-hides), same as a tap.
+            showOverlay = true
+            scheduleHideOverlay()
+        }
         .onChange(of: session.state) { newState in
             switch newState {
             case .connected:

--- a/ios/build.sh
+++ b/ios/build.sh
@@ -9,8 +9,17 @@
 #
 # Every launch path (dev / launch / iterate) starts a BACKGROUND log capture into ONE fixed file
 # (ios/logs/pylux.log) and returns immediately -- nothing streams in the foreground, so it never
-# hangs. We capture in the background because the simulator's `log show` does NOT retain .info logs.
-# To watch live instead of a snapshot:  tail -f ios/logs/pylux.log
+# hangs. To watch live instead of a snapshot:  tail -f ios/logs/pylux.log
+#
+# PHYSICAL DEVICE LOGS WORK OVER WI-FI -- NO USB CABLE NEEDED (since 2026-07-08).
+# The app is launched via `devicectl ... --console` with OS_ACTIVITY_DT_MODE=YES, which
+# streams os_log over the same CoreDevice channel deploys use: if install works, logs work.
+# Do NOT reach for idevicesyslog: it needs a legacy usbmux pairing this setup doesn't have,
+# and it will sit at "Waiting for device" forever while the log file stays empty.
+# Caveats of the console capture:
+#   - logs flow from APP LAUNCH (the launch and the capture are the same process);
+#     re-attaching to an already-running app without relaunching is not supported over Wi-Fi.
+#   - never TERM the capture pid (devicectl forwards signals to the app); stop-logs uses -9.
 # ======================================================================================
 #
 # Modes:
@@ -79,14 +88,29 @@ _pylux_start_phys_device_syslog_bg() {
     local udid="$1"
     local log_file="$2"
     local isys
+    # LOUD warning when the device isn't reachable over usbmux: idevicesyslog can
+    # only stream over USB (or Wi-Fi *sync* pairing). devicectl install/launch works
+    # over plain Wi-Fi, so builds succeed while the log stays empty -- which looks
+    # like "logging is broken" but just means THE CABLE IS NOT PLUGGED IN.
+    if ! idevice_id -l 2>/dev/null | grep -q . && ! idevice_id -ln 2>/dev/null | grep -q .; then
+        echo "WARN: device not visible over USB (idevice_id -l is empty)." >&2
+        echo "WARN: $log_file will stay EMPTY until the iPhone is plugged in via cable." >&2
+        echo "WARN: capture will attach automatically once it appears." >&2
+    fi
     isys=$(command -v idevicesyslog 2>/dev/null || true)
     if [ -n "$isys" ]; then
+        # Process filter flag differs across libimobiledevice versions: older
+        # builds use `-p <name>`, 1.4.0+ replaced it with `-m <match-string>`.
+        # Passing the wrong one makes idevicesyslog print usage and exit 0, so
+        # detect from --help instead of trying blind.
+        local filter=(-m Pylux)
+        "$isys" --help 2>&1 | grep -qE '^\s+-p, --process' && filter=(-p Pylux)
         if _pylux_idevicesyslog_use_network_flag "$udid"; then
-            echo "device syslog (bg): $isys -n -u $udid -p Pylux" >&2
-            "$isys" -n -u "$udid" -p Pylux >> "$log_file" 2>&1 &
+            echo "device syslog (bg): $isys -n -u $udid ${filter[*]}" >&2
+            "$isys" -n -u "$udid" "${filter[@]}" >> "$log_file" 2>&1 &
         else
-            echo "device syslog (bg): $isys -u $udid -p Pylux" >&2
-            "$isys" -u "$udid" -p Pylux >> "$log_file" 2>&1 &
+            echo "device syslog (bg): $isys -u $udid ${filter[*]}" >&2
+            "$isys" -u "$udid" "${filter[@]}" >> "$log_file" 2>&1 &
         fi
         PYLUX_SYSLOG_BG_PID=$!
     elif python3 -c "import pymobiledevice3" 2>/dev/null; then
@@ -100,6 +124,34 @@ _pylux_start_phys_device_syslog_bg() {
         exit 1
     fi
 }
+
+# ---- Guard: forbid struct-offset-dependent chiaki inline setters in app code ----
+# ChiakiSession's layout depends on the C lib's build config (e.g. the embedded
+# ChiakiECDH changes with CHIAKI_LIB_ENABLE_MBEDTLS). Xcode compiles ObjC/Swift
+# WITHOUT that config, so `static inline` setters from chiaki headers compute
+# WRONG field offsets and silently write into the void (2026-07-08: the haptics
+# sink registered this way stayed NULL inside the lib -> Remote Play rumble was
+# dead on iOS only; it cost days across multiple sessions to find).
+# ALWAYS use the CHIAKI_EXPORT `_ex` wrappers from lib/src/ios_bridge_helpers.c
+# (compiled inside the lib, correct offsets). Add new wrappers there as needed.
+check_forbidden_inline_setters() {
+    local forbidden="chiaki_session_set_event_cb|chiaki_session_set_video_sample_cb|chiaki_session_set_audio_sink|chiaki_session_set_haptics_sink|chiaki_session_ctrl_set_display_sink"
+    local hits
+    hits=$(grep -rnE "($forbidden)\(" "$SCRIPT_DIR/Pylux" --include="*.m" --include="*.mm" --include="*.swift" 2>/dev/null | grep -v "_ex(" || true)
+    if [ -n "$hits" ]; then
+        echo "" >&2
+        echo "BUILD BLOCKED: struct-offset-dependent chiaki inline setter called from app code:" >&2
+        echo "$hits" >&2
+        echo "" >&2
+        echo "These are 'static inline' in the chiaki headers; compiled by Xcode they use a" >&2
+        echo "DIFFERENT ChiakiSession layout than the C library and corrupt/miss the field." >&2
+        echo "Use the _ex wrapper from lib/src/ios_bridge_helpers.c instead" >&2
+        echo "(e.g. chiaki_session_set_haptics_sink_ex). See the comment above" >&2
+        echo "check_forbidden_inline_setters in this script for the full story." >&2
+        exit 1
+    fi
+}
+check_forbidden_inline_setters
 
 # Setup: Homebrew deps (match macOS build)
 if ! command -v brew &>/dev/null; then
@@ -249,23 +301,11 @@ run_dev() {
         INSTALL_UDID="${DEVICECTL_UDID:-$DEVICE_UDID}"
         xcrun devicectl device install app --device "$INSTALL_UDID" "$APP_PATH"
         
-        # Kill existing instance to ensure fresh start
-        xcrun devicectl device process kill --device "$INSTALL_UDID" "$BUNDLE_ID" 2>/dev/null || true
-        sleep 1
-        
-        xcrun devicectl device process launch --device "$INSTALL_UDID" "$BUNDLE_ID" || true
-        
+        # Launch + log capture in ONE step over CoreDevice (Wi-Fi or USB):
+        # console-attached launch streams os_log straight into logs/pylux.log.
+        launch_phys_with_console_log_bg "$INSTALL_UDID" "$BUNDLE_ID"
         echo ""
         echo "App launched on physical device: $DEVICE_NAME"
-        echo ""
-        
-        # Create logs directory and file
-        LOGS_DIR="$SCRIPT_DIR/logs"
-        mkdir -p "$LOGS_DIR"
-        LOG_FILE="$LOGS_DIR/pylux.log"
-        
-        SYSLOG_UDID="$(_pylux_resolve_syslog_udid "$DEVICE_UDID")"
-        start_phys_log_capture_bg "$SYSLOG_UDID" "$LOG_FILE"
         exit 0
     else
         echo "No physical device found, falling back to simulator"
@@ -483,19 +523,10 @@ run_launch() {
 
         echo "Found physical device: $DEVICE_NAME ($DEVICE_UDID)"
         echo ""
-        echo "=== Killing existing app instance (if running) ==="
-        xcrun devicectl device process kill --device "$DEVICE_UDID" com.pylux.stream 2>/dev/null || true
-        sleep 1
-        
-        echo "=== Launching app on physical device ==="
-        xcrun devicectl device process launch --device "$DEVICE_UDID" com.pylux.stream
-        
+        echo "=== Launching app with console log capture (CoreDevice, Wi-Fi or USB) ==="
+        launch_phys_with_console_log_bg "$DEVICE_UDID" com.pylux.stream
         echo ""
         echo "App launched on physical device: $DEVICE_NAME"
-        echo ""
-        
-        LOG_FILE="$SCRIPT_DIR/logs/pylux.log"
-        start_phys_log_capture_bg "$SYSLOG_UDID" "$LOG_FILE"
     else
         echo "No physical device found, launching on simulator"
         echo ""
@@ -607,37 +638,12 @@ run_iterate() {
         exit 1
     fi
 
-    echo "=== Install + launch ==="
+    echo "=== Install + launch (console log capture over CoreDevice, Wi-Fi or USB) ==="
     xcrun devicectl device install app --device "$INSTALL_UDID" "$APP_PATH"
-    xcrun devicectl device process kill --device "$INSTALL_UDID" "$BUNDLE_ID" 2>/dev/null || true
-    sleep 1
-    xcrun devicectl device process launch --device "$INSTALL_UDID" "$BUNDLE_ID" || true
+    launch_phys_with_console_log_bg "$INSTALL_UDID" "$BUNDLE_ID"
 
-    STOP_MIN="${PYLUX_LOG_MINUTES:-20}"
-    SESSION_TAG="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    printf '\n\n########## PYLUX STREAM SESSION %s ##########\n' "$SESSION_TAG" >> "$LOG_FILE"
-
-    SYSLOG_CAPTURE_UDID="$(_pylux_resolve_syslog_udid "$DEVICE_UDID")"
-    _pylux_start_phys_device_syslog_bg "$SYSLOG_CAPTURE_UDID" "$LOG_FILE"
-    CAPTURE_PID=$PYLUX_SYSLOG_BG_PID
-    echo "$CAPTURE_PID" > "$CAPTURE_PID_FILE"
-
-    # Detach the watchdog from the terminal's stdout/stderr/stdin so a piped `iterate | tail` returns.
-    (
-        sleep $((STOP_MIN * 60))
-        if kill -0 "$CAPTURE_PID" 2>/dev/null; then
-            kill "$CAPTURE_PID" 2>/dev/null || true
-        fi
-        rm -f "$CAPTURE_PID_FILE"
-        printf '\n########## SESSION END (auto %s min) %s ##########\n' "$STOP_MIN" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LOG_FILE"
-    ) >/dev/null 2>&1 </dev/null &
-
-    echo ""
-    echo "  App launched. Log capture PID $CAPTURE_PID → $LOG_FILE"
-    echo "  Auto-stops in ${STOP_MIN} min (set PYLUX_LOG_MINUTES to change)."
     echo ""
     echo "  → Open Pylux and press Stream."
-    echo "  → Stop early: ./build.sh stop-logs"
     echo "  → Live:  tail -f $LOG_FILE"
     echo "  → Grep:  grep 'Pylux VideoDecoder\\|displayed:' $LOG_FILE | tail -40"
     echo ""
@@ -673,7 +679,49 @@ start_sim_log_capture_bg() {
 }
 
 # --- Start a BACKGROUND physical-device syslog capture (mirror of the simulator path) ---
+# Launch the app on a physical device WITH LOGS in one step, over the CoreDevice
+# channel (Wi-Fi or USB -- if `devicectl install` works, this works; NO usbmux/USB
+# pairing needed). `--console` attaches the app's output and OS_ACTIVITY_DT_MODE=YES
+# mirrors os_log to that console (the same mechanism Xcode's console uses), streamed
+# into $LOG_FILE. This replaced the idevicesyslog capture on 2026-07-08: idevicesyslog
+# needs a legacy usbmux pairing this device does not have, so the log file silently
+# stayed empty while deploys (CoreDevice/Wi-Fi) kept working.
+# IMPORTANT: devicectl forwards catchable signals to the app, so the watchdog and
+# stop-logs must use kill -9 on this PID (SIGKILL detaches the console WITHOUT
+# killing the app; a plain TERM would terminate Pylux on the phone).
+launch_phys_with_console_log_bg() {
+    local devicectl_id="$1"
+    local bundle_id="$2"
+    local LOGS_DIR="$SCRIPT_DIR/logs"
+    mkdir -p "$LOGS_DIR"
+    local LOG_FILE="$LOGS_DIR/pylux.log"
+    local CAPTURE_PID_FILE="$LOGS_DIR/pylux-capture.pid"
+    local STOP_MIN="${PYLUX_LOG_MINUTES:-20}"
+    stop_logs >/dev/null 2>&1 || true
+    printf '\n########## DEVICE SESSION %s (devicectl console) ##########\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LOG_FILE"
+    nohup xcrun devicectl device process launch --terminate-existing --console \
+        -e '{"OS_ACTIVITY_DT_MODE":"YES"}' \
+        --device "$devicectl_id" "$bundle_id" >> "$LOG_FILE" 2>&1 &
+    local pid=$!
+    disown "$pid" 2>/dev/null || true
+    echo "$pid" > "$CAPTURE_PID_FILE"
+    # Detach the watchdog from the terminal's stdout/stderr/stdin, otherwise a `... | tail`/`| grep`
+    # on the launch command would block until this subshell exits (i.e. the whole auto-stop window).
+    ( sleep $((STOP_MIN * 60)); kill -9 "$pid" 2>/dev/null || true; rm -f "$CAPTURE_PID_FILE";
+      printf '\n########## SESSION END (auto %s min) %s ##########\n' "$STOP_MIN" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LOG_FILE" ) >/dev/null 2>&1 </dev/null &
+    disown 2>/dev/null || true
+    echo "  App launched with console log capture PID $pid -> $LOG_FILE (auto-stops in ${STOP_MIN}m)"
+    echo ""
+    echo "  VIEW LOGS (one-shot, never hangs):"
+    echo "    $0 logs                                  # tail -n 200 of $LOG_FILE"
+    echo "    $0 logs | grep 'Catalog cache invalidated'"
+    echo "  Stop capture:  $0 stop-logs"
+}
+
 start_phys_log_capture_bg() {
+    # Legacy usbmux/idevicesyslog capture -- kept only for manually attaching to an
+    # ALREADY-RUNNING app over a USB pairing. All launch paths now use
+    # launch_phys_with_console_log_bg instead (works over Wi-Fi).
     local udid="$1"
     local LOG_FILE="$2"
     local LOGS_DIR="$SCRIPT_DIR/logs"
@@ -686,16 +734,9 @@ start_phys_log_capture_bg() {
     local pid="$PYLUX_SYSLOG_BG_PID"
     disown "$pid" 2>/dev/null || true
     echo "$pid" > "$CAPTURE_PID_FILE"
-    # Detach the watchdog from the terminal's stdout/stderr/stdin, otherwise a `... | tail`/`| grep`
-    # on the launch command would block until this subshell exits (i.e. the whole auto-stop window).
     ( sleep $((STOP_MIN * 60)); kill "$pid" 2>/dev/null || true; rm -f "$CAPTURE_PID_FILE" ) >/dev/null 2>&1 </dev/null &
     disown 2>/dev/null || true
     echo "  Background log capture PID $pid -> $LOG_FILE (auto-stops in ${STOP_MIN}m)"
-    echo ""
-    echo "  VIEW LOGS (one-shot, never hangs):"
-    echo "    $0 logs                                  # tail -n 200 of $LOG_FILE"
-    echo "    $0 logs | grep 'Catalog cache invalidated'"
-    echo "  Stop capture:  $0 stop-logs"
 }
 
 # --- Stop log streaming (kill orphan processes) ---
@@ -705,10 +746,14 @@ stop_logs() {
     if [ -f "$CAPTURE_PID_FILE" ]; then
         CAPTURE_PID=$(head -1 "$CAPTURE_PID_FILE" 2>/dev/null || true)
         if [ -n "$CAPTURE_PID" ] && kill -0 "$CAPTURE_PID" 2>/dev/null; then
-            kill "$CAPTURE_PID" 2>/dev/null && { echo "Stopped capture PID $CAPTURE_PID"; killed=1; }
+            # SIGKILL, not TERM: the capture may be a `devicectl ... --console` process,
+            # which FORWARDS catchable signals to the app on the phone. -9 detaches the
+            # console without terminating Pylux.
+            kill -9 "$CAPTURE_PID" 2>/dev/null && { echo "Stopped capture PID $CAPTURE_PID"; killed=1; }
         fi
         rm -f "$CAPTURE_PID_FILE"
     fi
+    pkill -9 -f "devicectl device process launch.*--console" 2>/dev/null && { echo "Stopped devicectl console"; killed=1; }
     for proc in idevicesyslog pymobiledevice3; do
         if pgrep -f "$proc" >/dev/null 2>&1; then
             pkill -f "$proc" 2>/dev/null && { echo "Stopped $proc"; killed=1; }

--- a/lib/include/chiaki/audioreceiver.h
+++ b/lib/include/chiaki/audioreceiver.h
@@ -33,6 +33,7 @@ typedef struct chiaki_audio_receiver_t
 	ChiakiLog *log;
 	ChiakiMutex mutex;
 	ChiakiSeqNum16 frame_index_prev;
+	bool frame_index_prev_valid; // false until the first frame seeds frame_index_prev
 	bool frame_index_startup; // whether frame_index_prev has definitely not wrapped yet
 	ChiakiPacketStats *packet_stats;
 	void *pscloud_audio_reassembler; // Opaque pointer to ChiakiPSCLOUDAudioReassembler (PSCLOUD only)

--- a/lib/include/chiaki/feedbacksender.h
+++ b/lib/include/chiaki/feedbacksender.h
@@ -12,6 +12,23 @@
 extern "C" {
 #endif
 
+/**
+ * State for the unified "PS button via chord" feature: holding OPTIONS + SHARE
+ * together for hold_ms synthesizes a short BUTTON_PS pulse (and suppresses the
+ * two source buttons while the chord is held, so the console doesn't act on
+ * them). Implemented once here so every client (Qt, Android, iOS) gets an
+ * identical PS-button path — including iOS, where the physical PS/Home button
+ * is reserved by the OS and never delivered to apps.
+ */
+typedef struct chiaki_ps_chord_t
+{
+	bool enabled;
+	uint32_t hold_ms;         // chord hold time before the PS pulse fires
+	uint64_t chord_start_ms;  // 0 = chord not currently held
+	uint64_t pulse_until_ms;  // synthesized PS press active until this time
+	bool fired;               // latched: fire at most once per hold
+} ChiakiPsChord;
+
 typedef struct chiaki_feedback_sender_t
 {
 	ChiakiLog *log;
@@ -25,8 +42,14 @@ typedef struct chiaki_feedback_sender_t
 
 	bool should_stop;
 	ChiakiControllerState controller_state_prev;
+	// Last state as pushed by the platform, BEFORE the chord transform. Kept
+	// separately because the transform suppresses/synthesizes buttons over time
+	// (re-evaluated on every wake, incl. timeout ticks) while a steady hold
+	// produces no new platform pushes.
+	ChiakiControllerState controller_state_raw;
 	ChiakiControllerState controller_state;
 	bool controller_state_changed;
+	ChiakiPsChord ps_chord;
 	ChiakiMutex state_mutex;
 	ChiakiCond state_cond;
 } ChiakiFeedbackSender;
@@ -34,6 +57,16 @@ typedef struct chiaki_feedback_sender_t
 CHIAKI_EXPORT ChiakiErrorCode chiaki_feedback_sender_init(ChiakiFeedbackSender *feedback_sender, ChiakiTakion *takion);
 CHIAKI_EXPORT void chiaki_feedback_sender_fini(ChiakiFeedbackSender *feedback_sender);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_feedback_sender_set_controller_state(ChiakiFeedbackSender *feedback_sender, ChiakiControllerState *state);
+CHIAKI_EXPORT void chiaki_feedback_sender_set_ps_chord(ChiakiFeedbackSender *feedback_sender, bool enabled, uint32_t hold_ms);
+
+/**
+ * Apply the PS-chord transform to @a state (pure function of state+chord+now;
+ * exposed for unit tests). Mutates @a chord tracking fields and @a state's
+ * buttons: suppresses OPTIONS+SHARE while both are held, synthesizes BUTTON_PS
+ * for CHIAKI_PS_CHORD_PULSE_MS once the hold threshold is crossed.
+ */
+#define CHIAKI_PS_CHORD_PULSE_MS 150
+CHIAKI_EXPORT void chiaki_ps_chord_apply(ChiakiPsChord *chord, ChiakiControllerState *state, uint64_t now_ms);
 
 #ifdef __cplusplus
 }

--- a/lib/include/chiaki/feedbacksender.h
+++ b/lib/include/chiaki/feedbacksender.h
@@ -50,6 +50,10 @@ typedef struct chiaki_feedback_sender_t
 	ChiakiControllerState controller_state;
 	bool controller_state_changed;
 	ChiakiPsChord ps_chord;
+	// Invoked (outside state_mutex) on the rising edge of a chord fire, so the
+	// owner can emit a client event. NULL = no notification. Set by streamconnection.
+	void (*ps_chord_fired_cb)(void *user);
+	void *ps_chord_fired_user;
 	ChiakiMutex state_mutex;
 	ChiakiCond state_cond;
 } ChiakiFeedbackSender;
@@ -58,6 +62,13 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_feedback_sender_init(ChiakiFeedbackSender *
 CHIAKI_EXPORT void chiaki_feedback_sender_fini(ChiakiFeedbackSender *feedback_sender);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_feedback_sender_set_controller_state(ChiakiFeedbackSender *feedback_sender, ChiakiControllerState *state);
 CHIAKI_EXPORT void chiaki_feedback_sender_set_ps_chord(ChiakiFeedbackSender *feedback_sender, bool enabled, uint32_t hold_ms);
+
+/**
+ * Set the callback invoked (with state_mutex released) on the rising edge of a chord
+ * fire. Takes state_mutex so the store is published under the same lock the feedback
+ * thread reads it with. Pass NULL to disable.
+ */
+CHIAKI_EXPORT void chiaki_feedback_sender_set_ps_chord_fired_cb(ChiakiFeedbackSender *feedback_sender, void (*cb)(void *user), void *user);
 
 /**
  * Apply the PS-chord transform to @a state (pure function of state+chord+now;

--- a/lib/include/chiaki/ios_bridge_helpers.h
+++ b/lib/include/chiaki/ios_bridge_helpers.h
@@ -24,6 +24,12 @@
 // ║  4. Smaller structs (ChiakiSenkusha, ChiakiEvent, ChiakiConnectInfo,   ║
 // ║     ChiakiDiscoveryHost, etc.) are lower risk but could diverge too.   ║
 // ║     If you hit unexplained data corruption, check struct layout first. ║
+// ║  5. Rule 1 includes the `static inline` setters in the chiaki headers  ║
+// ║     (chiaki_session_set_haptics_sink & co.) — they are field access    ║
+// ║     compiled on the caller's side. Violating this made the haptics     ║
+// ║     sink NULL and killed Remote Play rumble on iOS (2026-07-08).       ║
+// ║     ios/build.sh now FAILS the build on such calls                     ║
+// ║     (check_forbidden_inline_setters).                                  ║
 // ╚══════════════════════════════════════════════════════════════════════════╝
 
 #ifndef CHIAKI_IOS_BRIDGE_HELPERS_H

--- a/lib/include/chiaki/session.h
+++ b/lib/include/chiaki/session.h
@@ -174,6 +174,7 @@ typedef enum {
 	CHIAKI_EVENT_PLAYER_INDEX,
 	CHIAKI_EVENT_HAPTIC_INTENSITY,
 	CHIAKI_EVENT_TRIGGER_INTENSITY,
+	CHIAKI_EVENT_PS_CHORD, // OPTIONS+SHARE chord fired: PS pulse still goes to the console; clients may also surface their own in-stream menu
 } ChiakiEventType;
 
 typedef struct chiaki_event_t

--- a/lib/include/chiaki/session.h
+++ b/lib/include/chiaki/session.h
@@ -289,6 +289,12 @@ typedef struct chiaki_session_t
 	ChiakiStreamConnection stream_connection;
 
 	ChiakiControllerState controller_state;
+
+	// Unified PS-button chord (OPTIONS+SHARE hold -> BUTTON_PS pulse), applied in
+	// the feedback sender. Stored here so platforms can configure it before the
+	// stream (feedback sender) exists; seeded on feedback-sender start.
+	bool ps_chord_enabled;
+	uint32_t ps_chord_hold_ms;
 } ChiakiSession;
 
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_init(ChiakiSession *session, ChiakiConnectInfo *connect_info, ChiakiLog *log);
@@ -297,6 +303,11 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_session_start(ChiakiSession *session);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_stop(ChiakiSession *session);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_join(ChiakiSession *session);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_controller_state(ChiakiSession *session, ChiakiControllerState *state);
+/**
+ * Configure the OPTIONS+SHARE -> PS chord (see ChiakiPsChord). Safe to call
+ * before or during a stream. hold_ms == 0 keeps the current hold duration.
+ */
+CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_ps_chord(ChiakiSession *session, bool enabled, uint32_t hold_ms);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_login_pin(ChiakiSession *session, const uint8_t *pin, size_t pin_size);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_stream_connection_switch_received(ChiakiSession *session);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_goto_bed(ChiakiSession *session);

--- a/lib/include/chiaki/session.h
+++ b/lib/include/chiaki/session.h
@@ -319,6 +319,23 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_session_keyboard_reject(ChiakiSession *sess
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_keyboard_accept(ChiakiSession *session);
 CHIAKI_EXPORT ChiakiErrorCode chiaki_session_go_home(ChiakiSession *session);
 
+/*
+ * ============================== WARNING ====================================
+ * The `static inline` setters below dereference ChiakiSession fields, so they
+ * compile with the CALLER's view of the struct layout. ChiakiSession's layout
+ * depends on the library's build config (e.g. the embedded ChiakiECDH differs
+ * with CHIAKI_LIB_ENABLE_MBEDTLS). Translation units built OUTSIDE the lib's
+ * CMake build (the iOS ObjC bridge, Swift via the bridging header) see a
+ * DIFFERENT layout: the write lands at the wrong offset and silently no-ops.
+ * 2026-07-08: exactly this made the haptics sink NULL inside the lib and
+ * killed Remote Play rumble on iOS only — days of debugging.
+ *
+ * From ios/Pylux (or any non-CMake consumer): use the CHIAKI_EXPORT `_ex`
+ * wrappers in lib/src/ios_bridge_helpers.c instead. ios/build.sh enforces
+ * this with a lint that fails the build. When adding a setter here, add a
+ * matching `_ex` wrapper there.
+ * ===========================================================================
+ */
 static inline void chiaki_session_set_event_cb(ChiakiSession *session, ChiakiEventCallback cb, void *user)
 {
 	session->event_cb = cb;

--- a/lib/src/audioreceiver.c
+++ b/lib/src/audioreceiver.c
@@ -25,6 +25,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_audio_receiver_init(ChiakiAudioReceiver *au
 	audio_receiver->packet_stats = packet_stats;
 
 	audio_receiver->frame_index_prev = 0;
+	audio_receiver->frame_index_prev_valid = false;
 	audio_receiver->frame_index_startup = true;
 	audio_receiver->pscloud_audio_reassembler = NULL;
 
@@ -178,8 +179,14 @@ static void chiaki_audio_receiver_frame(ChiakiAudioReceiver *audio_receiver, Chi
 {
 	chiaki_mutex_lock(&audio_receiver->mutex);
 
-	if(!chiaki_seq_num_16_gt(frame_index, audio_receiver->frame_index_prev))
+	// Seed the sequence tracker from the FIRST frame instead of assuming the
+	// stream starts near 0: the console's frame counter can begin anywhere in
+	// the 16-bit window (observed with PS5 haptics streams), and a start in the
+	// upper half made every frame test "older" than the initial 0 -- silently
+	// dropping the entire stream forever.
+	if(audio_receiver->frame_index_prev_valid && !chiaki_seq_num_16_gt(frame_index, audio_receiver->frame_index_prev))
 		goto beach;
+	audio_receiver->frame_index_prev_valid = true;
 	audio_receiver->frame_index_prev = frame_index;
 
 	if(is_haptics && audio_receiver->session->haptics_sink.frame_cb)

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -32,6 +32,10 @@
 #define MAX_LOCK_RETRIES 12
 #define DEFAULT_ALLOC_WAIT_S 300
 #define MAX_ALLOC_WAIT_S 900
+// Tolerate a few transient network blips (DNS-resolve / connect / TLS) during the
+// allocate poll loop before failing -- the slot is usually still coming.
+#define GK_ALLOC_MAX_NET_ERRORS 5
+#define GK_ALLOC_NET_RETRY_S 5
 
 typedef struct
 {
@@ -962,6 +966,7 @@ static ChiakiErrorCode gk_step13_allocate(GaikaiCtx *c, ChiakiCloudProvisionResu
 {
 	gk_progress(c, "Allocating Streaming Slot - Step 10 of 10");
 	int max_wait = DEFAULT_ALLOC_WAIT_S, elapsed = 0, attempt = 0;
+	int net_errors = 0; // consecutive transient network failures during the poll
 	bool wait_started = false;
 	for(;;)
 	{
@@ -989,7 +994,31 @@ static ChiakiErrorCode gk_step13_allocate(GaikaiCtx *c, ChiakiCloudProvisionResu
 
 		CCHttpResponse resp = { 0 };
 		ChiakiErrorCode e = gk_post_session(c, "/allocate", extra, &resp);
-		if(e != CHIAKI_ERR_SUCCESS) { cc_http_response_fini(&resp); return e; }
+		if(e != CHIAKI_ERR_SUCCESS)
+		{
+			// Transient network blip (DNS-resolve / connect / TLS) mid-allocation: the
+			// slot is usually still coming (we can be minutes into a queue/migration),
+			// so retry a few times rather than aborting the whole allocation on one drop.
+			cc_http_response_fini(&resp);
+			if(gk_cancelled(c)) return CHIAKI_ERR_CANCELED;
+			if(++net_errors > GK_ALLOC_MAX_NET_ERRORS || elapsed >= max_wait)
+			{
+				CHIAKI_LOGE(c->log, "[GAIKAI] allocate failed after %d consecutive network errors", net_errors);
+				free(out->error_message);
+				// Friendly message: clients show error_message verbatim when it isn't one
+				// of the known sentinels (AUTHORIZATION_FAILED, PS_PLUS_...), so this
+				// replaces the generic "Allocation failed" with the real cause.
+				out->error_message = strdup("Couldn't reach the cloud server (network error). Please try again.");
+				return e;
+			}
+			CHIAKI_LOGW(c->log, "[GAIKAI] allocate network error (%d/%d), retrying in %ds",
+				net_errors, GK_ALLOC_MAX_NET_ERRORS, GK_ALLOC_NET_RETRY_S);
+			gk_progress(c, "Allocating streaming slot - reconnecting...");
+			if(!gk_sleep_cancellable(c, GK_ALLOC_NET_RETRY_S)) return CHIAKI_ERR_CANCELED;
+			elapsed += GK_ALLOC_NET_RETRY_S;
+			continue;
+		}
+		net_errors = 0; // request completed -> network is back
 		if(resp.status_code != 200) { CHIAKI_LOGE(c->log, "[GAIKAI] step13 allocate http %ld: %s", resp.status_code, resp.data ? resp.data : ""); cc_http_response_fini(&resp); return CHIAKI_ERR_UNKNOWN; }
 		gk_update_session_key(c, &resp);
 		struct json_object *a = resp.data ? json_tokener_parse(resp.data) : NULL;

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -1024,12 +1024,23 @@ static ChiakiErrorCode gk_step13_allocate(GaikaiCtx *c, ChiakiCloudProvisionResu
 			if(gk_cancelled(c)) return CHIAKI_ERR_CANCELED;
 			if(++net_errors > GK_ALLOC_MAX_NET_ERRORS || elapsed >= max_wait)
 			{
-				CHIAKI_LOGE(c->log, "[GAIKAI] allocate failed after %d consecutive network errors", net_errors);
-				free(out->error_message);
 				// Friendly message: clients show error_message verbatim when it isn't one
-				// of the known sentinels (AUTHORIZATION_FAILED, PS_PLUS_...), so this
-				// replaces the generic "Allocation failed" with the real cause.
-				out->error_message = strdup("Couldn't reach the cloud server (network error). Please try again.");
+				// of the known sentinels (AUTHORIZATION_FAILED, PS_PLUS_...). Only blame
+				// the network on the consecutive-errors path -- a blip that happens to
+				// coincide with the allocation window expiring is a timeout, not an
+				// unreachable server.
+				if(net_errors > GK_ALLOC_MAX_NET_ERRORS)
+				{
+					CHIAKI_LOGE(c->log, "[GAIKAI] allocate failed after %d consecutive network errors", net_errors);
+					free(out->error_message);
+					out->error_message = strdup("Couldn't reach the cloud server (network error). Please try again.");
+				}
+				else
+				{
+					CHIAKI_LOGE(c->log, "[GAIKAI] allocate wait expired (%ds) during a network error", elapsed);
+					free(out->error_message);
+					out->error_message = strdup("Timed out waiting for a streaming slot. Please try again.");
+				}
 				return e;
 			}
 			CHIAKI_LOGW(c->log, "[GAIKAI] allocate network error (%d/%d), retrying in %ds",

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -545,12 +545,33 @@ static ChiakiErrorCode gk_step9_authorize(GaikaiCtx *c, ChiakiCloudProvisionResu
 static ChiakiErrorCode gk_step10_lock(GaikaiCtx *c)
 {
 	gk_progress(c, "Locking Session - Step 7 of 10");
+	int net_errors = 0; // consecutive transient network failures, like the allocate poll
 	for(int attempt = 0; attempt <= MAX_LOCK_RETRIES; attempt++)
 	{
 		if(gk_cancelled(c)) return CHIAKI_ERR_CANCELED;
 		CCHttpResponse resp = { 0 };
 		ChiakiErrorCode e = gk_post_session(c, "/lock?forceLogout=true", NULL, &resp);
-		if(e != CHIAKI_ERR_SUCCESS) { cc_http_response_fini(&resp); return e; }
+		if(e != CHIAKI_ERR_SUCCESS)
+		{
+			// Transient network blip (DNS-resolve / connect / TLS) on the lock call:
+			// retry like the allocate poll does instead of failing the whole
+			// provisioning on one dropped connection (observed as a single
+			// "SSL connect error" surfacing to the user as "Allocation failed").
+			cc_http_response_fini(&resp);
+			if(gk_cancelled(c)) return CHIAKI_ERR_CANCELED;
+			if(++net_errors > GK_ALLOC_MAX_NET_ERRORS)
+			{
+				CHIAKI_LOGE(c->log, "[GAIKAI] lock failed after %d consecutive network errors", net_errors);
+				return e;
+			}
+			CHIAKI_LOGW(c->log, "[GAIKAI] lock network error (%d/%d), retrying in %ds",
+				net_errors, GK_ALLOC_MAX_NET_ERRORS, GK_ALLOC_NET_RETRY_S);
+			gk_progress(c, "Locking Session - reconnecting...");
+			if(!gk_sleep_cancellable(c, GK_ALLOC_NET_RETRY_S)) return CHIAKI_ERR_CANCELED;
+			attempt--; // network retries don't consume lock attempts
+			continue;
+		}
+		net_errors = 0;
 		if(resp.status_code != 200) { CHIAKI_LOGE(c->log, "[GAIKAI] step10 lock http %ld", resp.status_code); cc_http_response_fini(&resp); return CHIAKI_ERR_UNKNOWN; }
 		gk_update_session_key(c, &resp);
 		struct json_object *j = resp.data ? json_tokener_parse(resp.data) : NULL;

--- a/lib/src/feedbacksender.c
+++ b/lib/src/feedbacksender.c
@@ -390,8 +390,13 @@ static void *feedback_sender_thread_func(void *user)
 		// fired" signal a client uses to also surface its own in-stream menu.
 		if(chord_just_fired && feedback_sender->ps_chord_fired_cb)
 		{
+			// Copy the pair while still holding the lock so a concurrent
+			// set_ps_chord_fired_cb can't be observed torn (cb from one
+			// registration, user from another).
+			void (*fired_cb)(void *user) = feedback_sender->ps_chord_fired_cb;
+			void *fired_user = feedback_sender->ps_chord_fired_user;
 			chiaki_mutex_unlock(&feedback_sender->state_mutex);
-			feedback_sender->ps_chord_fired_cb(feedback_sender->ps_chord_fired_user);
+			fired_cb(fired_user);
 			err = chiaki_mutex_lock(&feedback_sender->state_mutex);
 			if(err != CHIAKI_ERR_SUCCESS)
 				return NULL;

--- a/lib/src/feedbacksender.c
+++ b/lib/src/feedbacksender.c
@@ -24,6 +24,8 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_feedback_sender_init(ChiakiFeedbackSender *
 	feedback_sender->ps_chord.chord_start_ms = 0;
 	feedback_sender->ps_chord.pulse_until_ms = 0;
 	feedback_sender->ps_chord.fired = false;
+	feedback_sender->ps_chord_fired_cb = NULL;
+	feedback_sender->ps_chord_fired_user = NULL;
 
 	feedback_sender->state_seq_num = 0;
 
@@ -103,6 +105,15 @@ CHIAKI_EXPORT void chiaki_feedback_sender_set_ps_chord(ChiakiFeedbackSender *fee
 	feedback_sender->ps_chord.fired = false;
 	chiaki_mutex_unlock(&feedback_sender->state_mutex);
 	chiaki_cond_signal(&feedback_sender->state_cond);
+}
+
+CHIAKI_EXPORT void chiaki_feedback_sender_set_ps_chord_fired_cb(ChiakiFeedbackSender *feedback_sender, void (*cb)(void *user), void *user)
+{
+	if(chiaki_mutex_lock(&feedback_sender->state_mutex) != CHIAKI_ERR_SUCCESS)
+		return;
+	feedback_sender->ps_chord_fired_cb = cb;
+	feedback_sender->ps_chord_fired_user = user;
+	chiaki_mutex_unlock(&feedback_sender->state_mutex);
 }
 
 CHIAKI_EXPORT void chiaki_ps_chord_apply(ChiakiPsChord *chord, ChiakiControllerState *state, uint64_t now_ms)
@@ -347,8 +358,10 @@ static void *feedback_sender_thread_func(void *user)
 		// apart), so it must be re-evaluated on every wake and must never
 		// accumulate into the raw copy.
 		feedback_sender->controller_state = feedback_sender->controller_state_raw;
+		bool chord_fired_before = feedback_sender->ps_chord.fired;
 		chiaki_ps_chord_apply(&feedback_sender->ps_chord, &feedback_sender->controller_state,
 			chiaki_time_now_monotonic_ms());
+		bool chord_just_fired = !chord_fired_before && feedback_sender->ps_chord.fired;
 
 		// State packet: as upstream — re-send on every timeout (keepalive), and on
 		// input pushes only when something state-relevant changed.
@@ -369,6 +382,20 @@ static void *feedback_sender_thread_func(void *user)
 			feedback_sender_send_history(feedback_sender);
 
 		feedback_sender->controller_state_prev = feedback_sender->controller_state;
+
+		// The chord just crossed its hold threshold on this wake. Notify the owner
+		// OUTSIDE state_mutex -- the client callback may re-enter the lib (e.g. push
+		// a controller state), which would deadlock on this same mutex. The PS pulse
+		// itself already rode the history channel above; this is the extra "chord
+		// fired" signal a client uses to also surface its own in-stream menu.
+		if(chord_just_fired && feedback_sender->ps_chord_fired_cb)
+		{
+			chiaki_mutex_unlock(&feedback_sender->state_mutex);
+			feedback_sender->ps_chord_fired_cb(feedback_sender->ps_chord_fired_user);
+			err = chiaki_mutex_lock(&feedback_sender->state_mutex);
+			if(err != CHIAKI_ERR_SUCCESS)
+				return NULL;
+		}
 	}
 
 	chiaki_mutex_unlock(&feedback_sender->state_mutex);

--- a/lib/src/feedbacksender.c
+++ b/lib/src/feedbacksender.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
 
 #include <chiaki/feedbacksender.h>
+#include <chiaki/time.h>
 
 #define FEEDBACK_STATE_TIMEOUT_MIN_MS 8 // minimum time to wait between sending 2 packets
 #define FEEDBACK_STATE_TIMEOUT_MAX_MS 200 // maximum time to wait between sending 2 packets
@@ -15,7 +16,14 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_feedback_sender_init(ChiakiFeedbackSender *
 	feedback_sender->takion = takion;
 
 	chiaki_controller_state_set_idle(&feedback_sender->controller_state_prev);
+	chiaki_controller_state_set_idle(&feedback_sender->controller_state_raw);
 	chiaki_controller_state_set_idle(&feedback_sender->controller_state);
+
+	feedback_sender->ps_chord.enabled = false; // seeded from the session on stream start; opt-in only
+	feedback_sender->ps_chord.hold_ms = 2000;
+	feedback_sender->ps_chord.chord_start_ms = 0;
+	feedback_sender->ps_chord.pulse_until_ms = 0;
+	feedback_sender->ps_chord.fired = false;
 
 	feedback_sender->state_seq_num = 0;
 
@@ -66,19 +74,76 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_feedback_sender_set_controller_state(Chiaki
 	if(err != CHIAKI_ERR_SUCCESS)
 		return err;
 
-	if(chiaki_controller_state_equals(&feedback_sender->controller_state, state))
+	// Dedupe against the RAW state: controller_state is post-chord-transform and
+	// may legitimately differ from what platforms push (suppression/synthesis).
+	if(chiaki_controller_state_equals(&feedback_sender->controller_state_raw, state))
 	{
 		chiaki_mutex_unlock(&feedback_sender->state_mutex);
 		return CHIAKI_ERR_SUCCESS;
 	}
 
-	feedback_sender->controller_state = *state;
+	feedback_sender->controller_state_raw = *state;
 	feedback_sender->controller_state_changed = true;
 
 	chiaki_mutex_unlock(&feedback_sender->state_mutex);
 	chiaki_cond_signal(&feedback_sender->state_cond);
 
 	return CHIAKI_ERR_SUCCESS;
+}
+
+CHIAKI_EXPORT void chiaki_feedback_sender_set_ps_chord(ChiakiFeedbackSender *feedback_sender, bool enabled, uint32_t hold_ms)
+{
+	if(chiaki_mutex_lock(&feedback_sender->state_mutex) != CHIAKI_ERR_SUCCESS)
+		return;
+	feedback_sender->ps_chord.enabled = enabled;
+	if(hold_ms)
+		feedback_sender->ps_chord.hold_ms = hold_ms;
+	feedback_sender->ps_chord.chord_start_ms = 0;
+	feedback_sender->ps_chord.pulse_until_ms = 0;
+	feedback_sender->ps_chord.fired = false;
+	chiaki_mutex_unlock(&feedback_sender->state_mutex);
+	chiaki_cond_signal(&feedback_sender->state_cond);
+}
+
+CHIAKI_EXPORT void chiaki_ps_chord_apply(ChiakiPsChord *chord, ChiakiControllerState *state, uint64_t now_ms)
+{
+	if(!chord->enabled)
+		return;
+	const uint32_t both = CHIAKI_CONTROLLER_BUTTON_OPTIONS | CHIAKI_CONTROLLER_BUTTON_SHARE;
+	bool held = (state->buttons & both) == both;
+	if(held)
+	{
+		// Suppress the two source buttons while BOTH are held, so the console
+		// doesn't act on them during the hold (notably SHARE-hold opens the PS5
+		// capture menu). Note: this only covers the window where both are already
+		// down together — if the user presses them staggered (one clearly before
+		// the other), the first button is a normal press until the second joins,
+		// so a brief OPTIONS/SHARE tap can still reach the console. Pressing them
+		// together avoids that; we deliberately do NOT defer single presses (that
+		// would add latency to every OPTIONS/SHARE press for a cosmetic edge).
+		state->buttons &= ~both;
+		if(chord->chord_start_ms == 0)
+			chord->chord_start_ms = now_ms;
+		else if(!chord->fired && now_ms - chord->chord_start_ms >= chord->hold_ms)
+		{
+			chord->fired = true; // latch: at most one PS pulse per hold
+			chord->pulse_until_ms = now_ms + CHIAKI_PS_CHORD_PULSE_MS;
+		}
+	}
+	else
+	{
+		chord->chord_start_ms = 0;
+		chord->fired = false;
+	}
+	// The pulse outlives an early chord release so a started press always
+	// completes with a clean press/release edge pair on the history channel.
+	if(chord->pulse_until_ms)
+	{
+		if(now_ms < chord->pulse_until_ms)
+			state->buttons |= CHIAKI_CONTROLLER_BUTTON_PS;
+		else
+			chord->pulse_until_ms = 0;
+	}
 }
 
 static bool controller_state_equals_for_feedback_state(ChiakiControllerState *a, ChiakiControllerState *b)
@@ -259,20 +324,30 @@ static void *feedback_sender_thread_func(void *user)
 		if(feedback_sender->should_stop)
 			break;
 
-		bool send_feedback_state = true;
-		bool send_feedback_history = false;
+		// TODO: FEEDBACK_STATE_TIMEOUT_MIN_MS
+		bool timeout_wake = !feedback_sender->controller_state_changed;
+		feedback_sender->controller_state_changed = false;
 
-		if(feedback_sender->controller_state_changed)
-		{
-			// TODO: FEEDBACK_STATE_TIMEOUT_MIN_MS
-			feedback_sender->controller_state_changed = false;
+		// Rebuild the outgoing state from the raw platform state and re-run the
+		// PS-chord transform: the chord's suppression/pulse evolves over time even
+		// when no new input arrives (timeout wakes, <=FEEDBACK_STATE_TIMEOUT_MAX_MS
+		// apart), so it must be re-evaluated on every wake and must never
+		// accumulate into the raw copy.
+		feedback_sender->controller_state = feedback_sender->controller_state_raw;
+		chiaki_ps_chord_apply(&feedback_sender->ps_chord, &feedback_sender->controller_state,
+			chiaki_time_now_monotonic_ms());
 
-			// don't need to send feedback state if nothing relevant changed
-			if(controller_state_equals_for_feedback_state(&feedback_sender->controller_state, &feedback_sender->controller_state_prev))
-				send_feedback_state = false;
+		// State packet: as upstream — re-send on every timeout (keepalive), and on
+		// input pushes only when something state-relevant changed.
+		bool send_feedback_state = timeout_wake
+			|| !controller_state_equals_for_feedback_state(&feedback_sender->controller_state, &feedback_sender->controller_state_prev);
 
-			send_feedback_history = !controller_state_equals_for_feedback_history(&feedback_sender->controller_state, &feedback_sender->controller_state_prev);
-		} // else: timeout
+		// History (button events): unlike upstream, diff on EVERY wake — chord-
+		// synthesized button edges (PS press/release, OPTIONS+SHARE suppression)
+		// can appear on timeout wakes without any platform push, and buttons ride
+		// the history channel. With the chord idle this reduces to upstream
+		// behavior (cur == prev on timeout wakes).
+		bool send_feedback_history = !controller_state_equals_for_feedback_history(&feedback_sender->controller_state, &feedback_sender->controller_state_prev);
 
 		if(send_feedback_state)
 			feedback_sender_send_state(feedback_sender);

--- a/lib/src/feedbacksender.c
+++ b/lib/src/feedbacksender.c
@@ -115,12 +115,13 @@ CHIAKI_EXPORT void chiaki_ps_chord_apply(ChiakiPsChord *chord, ChiakiControllerS
 	{
 		// Suppress the two source buttons while BOTH are held, so the console
 		// doesn't act on them during the hold (notably SHARE-hold opens the PS5
-		// capture menu). Note: this only covers the window where both are already
-		// down together — if the user presses them staggered (one clearly before
-		// the other), the first button is a normal press until the second joins,
-		// so a brief OPTIONS/SHARE tap can still reach the console. Pressing them
-		// together avoids that; we deliberately do NOT defer single presses (that
-		// would add latency to every OPTIONS/SHARE press for a cosmetic edge).
+		// capture menu). The staggered *release* tail is handled in the branch
+		// below. The staggered *press* entry is not: if the user presses them
+		// clearly one-then-the-other, the first is a normal press until the second
+		// joins, so a brief OPTIONS/SHARE tap can still reach the console. We
+		// deliberately do NOT defer single presses to close that -- it would add
+		// latency to every OPTIONS/SHARE press for a cosmetic edge; pressing the
+		// two together (the natural chord motion) avoids it.
 		state->buttons &= ~both;
 		if(chord->chord_start_ms == 0)
 			chord->chord_start_ms = now_ms;
@@ -129,6 +130,18 @@ CHIAKI_EXPORT void chiaki_ps_chord_apply(ChiakiPsChord *chord, ChiakiControllerS
 			chord->fired = true; // latch: at most one PS pulse per hold
 			chord->pulse_until_ms = now_ms + CHIAKI_PS_CHORD_PULSE_MS;
 		}
+	}
+	else if(chord->chord_start_ms != 0 && (state->buttons & both))
+	{
+		// Both buttons were down together (chord engaged -- whether or not it
+		// reached the PS threshold) and now exactly one is still held mid-release.
+		// Keep consuming it until BOTH are up. Releases are practically never on
+		// the same frame, so without this the button let go of last lands as a
+		// real press: SHARE opening the capture gallery on top of the PS home
+		// overlay the chord just summoned, or a stray OPTIONS/SHARE if the user
+		// aborts the hold before it fires. chord_start_ms/fired are left intact so
+		// a fresh press of both is required before it can fire again.
+		state->buttons &= ~both;
 	}
 	else
 	{

--- a/lib/src/orientation.c
+++ b/lib/src/orientation.c
@@ -200,6 +200,19 @@ CHIAKI_EXPORT void chiaki_orientation_tracker_apply_to_controller_state(ChiakiOr
 	state->accel_x = tracker->accel_x;
 	state->accel_y = tracker->accel_y;
 	state->accel_z = tracker->accel_z;
+	// During warmup the filter is still slewing from its init pose toward the
+	// accel-measured attitude at BETA_WARMUP -- the intermediate quaternions are
+	// meaningless thrash that renders as the controller whipping around. Hold
+	// identity until warmup completes; gyro/accel above are raw passthrough and
+	// stay live throughout.
+	if(tracker->sample_index < WARMUP_SAMPLES_COUNT)
+	{
+		state->orient_x = 0.0f;
+		state->orient_y = 0.0f;
+		state->orient_z = 0.0f;
+		state->orient_w = 1.0f;
+		return;
+	}
 	// -90 deg rotation around x from Madgwick
 	state->orient_w = COS_NEG_1_4_PI * tracker->orient.w - SIN_NEG_1_4_PI * tracker->orient.x;
 	state->orient_x = COS_NEG_1_4_PI * tracker->orient.x + SIN_NEG_1_4_PI * tracker->orient.w;

--- a/lib/src/session.c
+++ b/lib/src/session.c
@@ -397,6 +397,12 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_session_init(ChiakiSession *session, Chiaki
 
 	chiaki_controller_state_set_idle(&session->controller_state);
 
+	// Default OFF in the lib: only frontends that explicitly call
+	// chiaki_session_set_ps_chord (Qt/Android/iOS, default on via their own pref)
+	// opt in. Unwired frontends (cli, switch, ...) keep normal OPTIONS+SHARE.
+	session->ps_chord_enabled = false;
+	session->ps_chord_hold_ms = 2000;
+
 	session->connect_info.ps5 = connect_info->ps5;
 	const uint8_t did_prefix[] = { 0x00, 0x18, 0x00, 0x00, 0x00, 0x07, 0x00, 0x40, 0x00, 0x80 };
 	const uint8_t did_suffix[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
@@ -487,6 +493,20 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_controller_state(ChiakiSession 
 	session->controller_state = *state;
 	if(session->stream_connection.feedback_sender_active)
 		chiaki_feedback_sender_set_controller_state(&session->stream_connection.feedback_sender, &session->controller_state);
+	chiaki_mutex_unlock(&session->stream_connection.feedback_sender_mutex);
+	return CHIAKI_ERR_SUCCESS;
+}
+
+CHIAKI_EXPORT ChiakiErrorCode chiaki_session_set_ps_chord(ChiakiSession *session, bool enabled, uint32_t hold_ms)
+{
+	ChiakiErrorCode err = chiaki_mutex_lock(&session->stream_connection.feedback_sender_mutex);
+	if(err != CHIAKI_ERR_SUCCESS)
+		return err;
+	session->ps_chord_enabled = enabled;
+	if(hold_ms)
+		session->ps_chord_hold_ms = hold_ms;
+	if(session->stream_connection.feedback_sender_active)
+		chiaki_feedback_sender_set_ps_chord(&session->stream_connection.feedback_sender, enabled, hold_ms);
 	chiaki_mutex_unlock(&session->stream_connection.feedback_sender_mutex);
 	return CHIAKI_ERR_SUCCESS;
 }

--- a/lib/src/streamconnection.c
+++ b/lib/src/streamconnection.c
@@ -335,6 +335,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_stream_connection_run(ChiakiStreamConnectio
 		goto disconnect;
 	}
 	stream_connection->feedback_sender_active = true;
+	chiaki_feedback_sender_set_ps_chord(&stream_connection->feedback_sender, session->ps_chord_enabled, session->ps_chord_hold_ms);
 	chiaki_feedback_sender_set_controller_state(&stream_connection->feedback_sender, &session->controller_state);
 	chiaki_mutex_unlock(&stream_connection->feedback_sender_mutex);
 

--- a/lib/src/streamconnection.c
+++ b/lib/src/streamconnection.c
@@ -55,6 +55,16 @@ typedef enum {
 
 void chiaki_session_send_event(ChiakiSession *session, ChiakiEvent *event);
 
+// Bridges a feedback-sender PS-chord fire to a client event. Invoked on the
+// feedback-sender thread with its state_mutex released; @a user is the session.
+static void stream_connection_ps_chord_fired(void *user)
+{
+	ChiakiSession *session = user;
+	ChiakiEvent event = { 0 };
+	event.type = CHIAKI_EVENT_PS_CHORD;
+	chiaki_session_send_event(session, &event);
+}
+
 static void stream_connection_takion_cb(ChiakiTakionEvent *event, void *user);
 static void stream_connection_takion_data(ChiakiStreamConnection *stream_connection, ChiakiTakionMessageDataType data_type, uint8_t *buf, size_t buf_size);
 static void stream_connection_takion_data_protobuf(ChiakiStreamConnection *stream_connection, uint8_t *buf, size_t buf_size);
@@ -335,6 +345,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_stream_connection_run(ChiakiStreamConnectio
 		goto disconnect;
 	}
 	stream_connection->feedback_sender_active = true;
+	chiaki_feedback_sender_set_ps_chord_fired_cb(&stream_connection->feedback_sender, stream_connection_ps_chord_fired, session);
 	chiaki_feedback_sender_set_ps_chord(&stream_connection->feedback_sender, session->ps_chord_enabled, session->ps_chord_hold_ms);
 	chiaki_feedback_sender_set_controller_state(&stream_connection->feedback_sender, &session->controller_state);
 	chiaki_mutex_unlock(&stream_connection->feedback_sender_mutex);

--- a/lib/src/streamconnection.c
+++ b/lib/src/streamconnection.c
@@ -1405,7 +1405,7 @@ static void stream_connection_takion_av(ChiakiStreamConnection *stream_connectio
 	if(packet->is_video)
 		chiaki_video_receiver_av_packet(stream_connection->video_receiver, packet);
 	else if(packet->is_haptics)
-	    chiaki_audio_receiver_av_packet(stream_connection->haptics_receiver, packet);
+		chiaki_audio_receiver_av_packet(stream_connection->haptics_receiver, packet);
 	else
 		chiaki_audio_receiver_av_packet(stream_connection->audio_receiver, packet);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,8 @@ add_executable(chiaki-unit
 		bitstream.c
 		regist.c
 		cloudcatalog_merge.c
-		cloudsession_kamaji.c)
+		cloudsession_kamaji.c
+		pschord.c)
 
 target_link_libraries(chiaki-unit chiaki-lib munit)
 if(TARGET PkgConfig::json-c)

--- a/test/main.c
+++ b/test/main.c
@@ -14,6 +14,7 @@ extern MunitTest tests_regist[];
 extern MunitTest tests_bitstream[];
 extern MunitTest tests_cloudcatalog_merge[];
 extern MunitTest tests_cloudsession_kamaji[];
+extern MunitTest tests_ps_chord[];
 
 static MunitSuite suites[] = {
 	{
@@ -96,6 +97,13 @@ static MunitSuite suites[] = {
 	{
 		"/cloudsession_kamaji",
 		tests_cloudsession_kamaji,
+		NULL,
+		1,
+		MUNIT_SUITE_OPTION_NONE
+	},
+	{
+		"/ps_chord",
+		tests_ps_chord,
 		NULL,
 		1,
 		MUNIT_SUITE_OPTION_NONE

--- a/test/pschord.c
+++ b/test/pschord.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
+//
+// Tests for the unified PS-button chord transform (chiaki_ps_chord_apply):
+// OPTIONS+SHARE held >= hold_ms -> one synthesized BUTTON_PS pulse, with the
+// two source buttons suppressed for the duration of the hold.
+
+#include <munit.h>
+
+#include <chiaki/feedbacksender.h>
+#include <chiaki/controller.h>
+
+#define CHORD_BITS (CHIAKI_CONTROLLER_BUTTON_OPTIONS | CHIAKI_CONTROLLER_BUTTON_SHARE)
+
+static ChiakiPsChord chord_default(void)
+{
+	ChiakiPsChord chord = { 0 };
+	chord.enabled = true;
+	chord.hold_ms = 2000;
+	return chord;
+}
+
+static ChiakiControllerState state_with_buttons(uint32_t buttons)
+{
+	ChiakiControllerState state;
+	chiaki_controller_state_set_idle(&state);
+	state.buttons = buttons;
+	return state;
+}
+
+static MunitResult test_suppression_and_no_fire_below_threshold(const MunitParameter params[], void *user)
+{
+	ChiakiPsChord chord = chord_default();
+
+	ChiakiControllerState state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000);
+	munit_assert_uint32(state.buttons & CHORD_BITS, ==, 0); // suppressed from the first wake
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, ==, 0);
+
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000 + 1999); // 1ms short of the threshold
+	munit_assert_uint32(state.buttons & CHORD_BITS, ==, 0);
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, ==, 0);
+	return MUNIT_OK;
+}
+
+static MunitResult test_fires_once_with_pulse_then_release(const MunitParameter params[], void *user)
+{
+	ChiakiPsChord chord = chord_default();
+
+	ChiakiControllerState state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000); // chord starts
+
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 3000); // threshold crossed -> pulse starts
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, !=, 0);
+	munit_assert_uint32(state.buttons & CHORD_BITS, ==, 0);
+
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 3000 + CHIAKI_PS_CHORD_PULSE_MS - 1); // still inside the pulse
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, !=, 0);
+
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 3000 + CHIAKI_PS_CHORD_PULSE_MS); // pulse over -> PS released
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, ==, 0);
+
+	// latched: keep holding well past another hold interval -> no second pulse
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 10000);
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, ==, 0);
+	return MUNIT_OK;
+}
+
+static MunitResult test_rearm_after_release(const MunitParameter params[], void *user)
+{
+	ChiakiPsChord chord = chord_default();
+
+	ChiakiControllerState state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000);
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 3000); // fired
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 4000); // pulse over, still held: latched
+
+	state = state_with_buttons(0); // full release
+	chiaki_ps_chord_apply(&chord, &state, 5000);
+	munit_assert_uint32(state.buttons, ==, 0);
+
+	// re-hold: fires again after a fresh hold interval
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 6000);
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 8000);
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, !=, 0);
+	return MUNIT_OK;
+}
+
+static MunitResult test_early_release_completes_pulse(const MunitParameter params[], void *user)
+{
+	ChiakiPsChord chord = chord_default();
+
+	ChiakiControllerState state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000);
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 3000); // pulse until 3000 + PULSE_MS
+
+	// chord released mid-pulse: the started press still completes...
+	state = state_with_buttons(0);
+	chiaki_ps_chord_apply(&chord, &state, 3050);
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, !=, 0);
+
+	// ...and cleanly releases afterwards
+	state = state_with_buttons(0);
+	chiaki_ps_chord_apply(&chord, &state, 3000 + CHIAKI_PS_CHORD_PULSE_MS + 10);
+	munit_assert_uint32(state.buttons, ==, 0);
+	return MUNIT_OK;
+}
+
+static MunitResult test_disabled_passthrough_and_other_buttons(const MunitParameter params[], void *user)
+{
+	ChiakiPsChord chord = chord_default();
+	chord.enabled = false;
+
+	ChiakiControllerState state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000);
+	chiaki_ps_chord_apply(&chord, &state, 5000);
+	munit_assert_uint32(state.buttons, ==, CHORD_BITS); // untouched when disabled
+
+	// enabled: unrelated buttons pass through while the chord is suppressed
+	chord = chord_default();
+	state = state_with_buttons(CHORD_BITS | CHIAKI_CONTROLLER_BUTTON_CROSS);
+	chiaki_ps_chord_apply(&chord, &state, 1000);
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_CROSS, !=, 0);
+	munit_assert_uint32(state.buttons & CHORD_BITS, ==, 0);
+
+	// single-button presses are never suppressed
+	chord = chord_default();
+	state = state_with_buttons(CHIAKI_CONTROLLER_BUTTON_SHARE);
+	chiaki_ps_chord_apply(&chord, &state, 1000);
+	munit_assert_uint32(state.buttons, ==, CHIAKI_CONTROLLER_BUTTON_SHARE);
+	return MUNIT_OK;
+}
+
+MunitTest tests_ps_chord[] = {
+	{ "/suppression_and_threshold", test_suppression_and_no_fire_below_threshold, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/fires_once_with_pulse", test_fires_once_with_pulse_then_release, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/rearm_after_release", test_rearm_after_release, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/early_release_completes_pulse", test_early_release_completes_pulse, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/disabled_passthrough", test_disabled_passthrough_and_other_buttons, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+};

--- a/test/pschord.c
+++ b/test/pschord.c
@@ -115,6 +115,73 @@ static MunitResult test_early_release_completes_pulse(const MunitParameter param
 	return MUNIT_OK;
 }
 
+static MunitResult test_staggered_release_after_fire_is_consumed(const MunitParameter params[], void *user)
+{
+	// Regression: after the chord fires, the user is still holding both buttons
+	// and releases them a few frames apart. The button released LAST must not
+	// land as a real press (SHARE would otherwise open the PS5 capture gallery
+	// on top of the home overlay the chord just opened).
+	ChiakiPsChord chord = chord_default();
+
+	ChiakiControllerState state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000);   // chord starts
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 3000);   // threshold crossed -> fired + pulse
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, !=, 0);
+
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 3000 + CHIAKI_PS_CHORD_PULSE_MS); // pulse over, both still down
+	munit_assert_uint32(state.buttons, ==, 0);
+
+	// OPTIONS released first, SHARE still held -> SHARE must stay consumed
+	state = state_with_buttons(CHIAKI_CONTROLLER_BUTTON_SHARE);
+	chiaki_ps_chord_apply(&chord, &state, 3500);
+	munit_assert_uint32(state.buttons, ==, 0);
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, ==, 0);
+
+	// keeps hanging on to SHARE much longer -> still consumed, no second pulse
+	state = state_with_buttons(CHIAKI_CONTROLLER_BUTTON_SHARE);
+	chiaki_ps_chord_apply(&chord, &state, 6000);
+	munit_assert_uint32(state.buttons, ==, 0);
+
+	// full release re-arms; a later lone SHARE tap passes through normally
+	state = state_with_buttons(0);
+	chiaki_ps_chord_apply(&chord, &state, 6100);
+	state = state_with_buttons(CHIAKI_CONTROLLER_BUTTON_SHARE);
+	chiaki_ps_chord_apply(&chord, &state, 6200);
+	munit_assert_uint32(state.buttons, ==, CHIAKI_CONTROLLER_BUTTON_SHARE);
+	return MUNIT_OK;
+}
+
+static MunitResult test_staggered_release_before_fire_is_consumed(const MunitParameter params[], void *user)
+{
+	// Regression: the user engages the chord (both down) but lets go BEFORE the
+	// 2s threshold, releasing the two buttons a few frames apart. The button
+	// released last must not leak -- aborting the hold shouldn't fire OPTIONS or
+	// open the SHARE capture menu.
+	ChiakiPsChord chord = chord_default();
+
+	ChiakiControllerState state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1000);   // engaged (both down), not fired
+	munit_assert_uint32(state.buttons, ==, 0);
+	state = state_with_buttons(CHORD_BITS);
+	chiaki_ps_chord_apply(&chord, &state, 1500);   // still under threshold
+	munit_assert_uint32(state.buttons & CHIAKI_CONTROLLER_BUTTON_PS, ==, 0); // never fired
+
+	// OPTIONS released first, SHARE lingers -> SHARE consumed, not leaked
+	state = state_with_buttons(CHIAKI_CONTROLLER_BUTTON_SHARE);
+	chiaki_ps_chord_apply(&chord, &state, 1600);
+	munit_assert_uint32(state.buttons, ==, 0);
+
+	// full release re-arms; a later lone SHARE tap passes through normally
+	state = state_with_buttons(0);
+	chiaki_ps_chord_apply(&chord, &state, 1700);
+	state = state_with_buttons(CHIAKI_CONTROLLER_BUTTON_SHARE);
+	chiaki_ps_chord_apply(&chord, &state, 1800);
+	munit_assert_uint32(state.buttons, ==, CHIAKI_CONTROLLER_BUTTON_SHARE);
+	return MUNIT_OK;
+}
+
 static MunitResult test_disabled_passthrough_and_other_buttons(const MunitParameter params[], void *user)
 {
 	ChiakiPsChord chord = chord_default();
@@ -145,6 +212,8 @@ MunitTest tests_ps_chord[] = {
 	{ "/fires_once_with_pulse", test_fires_once_with_pulse_then_release, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/rearm_after_release", test_rearm_after_release, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/early_release_completes_pulse", test_early_release_completes_pulse, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/staggered_release_after_fire", test_staggered_release_after_fire_is_consumed, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/staggered_release_before_fire", test_staggered_release_before_fire_is_consumed, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/disabled_passthrough", test_disabled_passthrough_and_other_buttons, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };


### PR DESCRIPTION
## Summary

Brings the controller experience to full DualSense parity on every platform, with iOS — previously the furthest behind — now matching desktop as closely as Apple's APIs allow. Also fixes Qt settings navigation, hardens cloud provisioning against transient network errors, and adds developer guardrails that prevent an entire class of iOS↔C ABI bugs.

## Controller features

### iOS (the bulk of this PR)
- **Remote Play rumble** (was completely dead on iOS): the haptics sink was registered through a `static inline` chiaki setter whose struct offset is computed against the Xcode-side view of `ChiakiSession` — the pointer landed in the wrong memory and the lib saw NULL forever. Now registered via the `_ex` wrapper compiled inside the lib. `enable_dualsense` is also advertised unconditionally (an RP PS5 sends rumble ONLY as DualSense haptic audio) and the haptic-audio→rumble converter is always on.
- **Adaptive triggers**: games speak the extended DualSense effect modes (zoned feedback, bow, galloping, weapon, vibration, machine) — previously only the three legacy simple modes were mapped, so triggers did nothing in practice. All extended modes are now decoded (zone masks, packed per-zone magnitudes) into `GCDualSenseAdaptiveTrigger` semantic calls. Zero magnitude = off (no phantom buzz). Desktop passes raw HID via SDL; Apple has no raw path, so this translation is the iOS equivalent.
- **Console intensity settings honored like Qt**: the PS5's Vibration Intensity scales rumble; Trigger Effect Intensity scales effects and Off skips + releases them.
- **Motion / gyro**: controller (GCMotion) or device (CoreMotion) motion streamed through the shared orientation tracker, with a new 4-way **Gyro / Motion** setting: Auto (controller, falls back to phone) / Controller only / Phone only / Off. Axes remapped to the PS Y-up frame; sensors follow hotplug and live preference changes.
- **Rumble Intensity setting**: 0–500% slider (default 100%), Android's exact scaling formula.
- **Touchpad**: swipes register from a light touch (finger presence now derived from pad axes — GameController's `isTouched` tracks the click, which forced click-and-drag and made plain clicks unusable).
- **In-stream menu chord (Create+Options)**: iOS binds the Create button to system capture gestures by default and swallows the presses; the stream now claims Create/Options/PS via `preferredSystemGestureState`, so the chord works and PS reaches the console.
- Settings rows no longer overlap captions; Disconnect button stays on one line; Info.plist declares the Game Controllers capability keys.

### Android
- Remote Play rumble via `enable_dualsense=true` + haptic-audio→motor sink, physical DualSense touchpad capture, rumble intensity setting, in-stream menu chord.

### Qt / desktop
- In-stream menu chord; settings key/controller navigation fixed on macOS (`Qt::TabFocusAllControls` + deterministic dialog focus seeding — Down previously did nothing until a control was clicked, and only hand-wired tabs worked).

## Shared C
- Audio receiver seeds its sequence tracking from the first frame received instead of assuming streams start near frame 0 (a stream starting in the upper half of the 16-bit window was silently dropped forever).
- OPTIONS+SHARE chord raises `CHIAKI_EVENT_PS_CHORD` so every client opens its own in-stream menu.
- Cloud provisioning: transient network errors (DNS/connect/TLS) during the Gaikai **allocate** poll and **lock** step retry with backoff instead of failing the session (previously surfaced as a spurious "Allocation failed").

## Developer guardrails
- `ios/build.sh` fails the build if app code calls a struct-offset-dependent chiaki inline setter instead of its `_ex` wrapper (the exact bug class that silently killed RP rumble), and documents the ABI trap at the definition sites.
- iOS device logs now stream over Wi-Fi via `devicectl --console` (launch and capture are one step; no USB/usbmux pairing needed).
- New repo-root `CLAUDE.md`: shared-C-first architecture, structural title-ID matching, per-platform build/verify workflows, and the iOS↔C boundary rules.
- Release builds stay quiet: the chiaki log mask is errors-only outside DEBUG, and chatty per-tick discovery logs moved to `.info` (not persisted).

## Testing
- All iOS features verified on a physical iPhone (iOS 26) with a DualSense over Bluetooth: RP rumble + intensity scaling, adaptive triggers in a game using extended modes, chord, touchpad swipes/clicks, motion streaming, settings UI.
- Qt settings navigation verified on macOS by keyboard-driving all nine settings tabs.
- Cloud lock/allocate retry paths exercised against live Gaikai provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)