### PR TITLE
Pre-master review fixes: ping-thread UAF, stale-account catalog, dead iOS cancel

### DIFF
--- a/gui/include/cloudcatalogbackend.h
+++ b/gui/include/cloudcatalogbackend.h
@@ -101,6 +101,13 @@ private:
     std::atomic<bool> unifiedFetchInFlight{false};
     std::vector<QJSValue> pendingUnifiedCallbacks;
 
+    // Bumped by invalidateCache() (GUI thread only). A unified fetch snapshots it
+    // at start; a completion whose snapshot is stale means the cache (and account/
+    // locale inputs) changed mid-flight — the result must be discarded and the
+    // fetch restarted, or a coalesced reload after an account switch would serve
+    // (and re-persist) the previous account's catalog.
+    quint64 catalogGeneration = 0;
+
     QHash<quint64, QJSValue> pending_callbacks; // GUI thread only
     quint64 next_request_id = 0;
 

--- a/gui/src/cloudcatalogbackend.cpp
+++ b/gui/src/cloudcatalogbackend.cpp
@@ -229,12 +229,17 @@ void CloudCatalogBackend::fetchUnifiedCatalog(const QJSValue &callback)
     pending_callbacks.insert(reqId, cb);
     QPointer<CloudCatalogBackend> self(this);
 
+    // Snapshot the invalidation generation with the npsso/locale inputs: if
+    // invalidateCache() runs while the worker is in flight, the completion handler
+    // discards this fetch's result and restarts with the then-current inputs.
+    const quint64 gen = catalogGeneration;
+
     const QByteArray npsso = getNpSsoToken().toUtf8();
     const QByteArray locale =
         (settings ? settings->GetCloudStoreLocale() : QStringLiteral("en-US")).toUtf8();
     const QByteArray cacheDir = cacheDirectory.toUtf8();
 
-    std::thread([self, reqId, npsso, locale, cacheDir]() mutable {
+    std::thread([self, reqId, gen, npsso, locale, cacheDir]() mutable {
         ChiakiLog log;
         chiaki_log_init(&log, CHIAKI_LOG_INFO | CHIAKI_LOG_WARNING | CHIAKI_LOG_ERROR,
                         chiaki_log_cb_print, nullptr);
@@ -258,13 +263,32 @@ void CloudCatalogBackend::fetchUnifiedCatalog(const QJSValue &callback)
         // QJSValue must be invoked on the engine (main) thread. Route through qApp so
         // the callback is fetched and invoked on the GUI thread even if `self` is
         // destroyed before the worker finishes.
-        QMetaObject::invokeMethod(qApp, [self, reqId, success, message, json]() mutable {
+        QMetaObject::invokeMethod(qApp, [self, reqId, gen, success, message, json]() mutable {
             if (!self)
                 return; // backend destroyed while the worker ran
             const QJSValue cb = self->pending_callbacks.take(reqId);
             std::vector<QJSValue> parked;
             parked.swap(self->pendingUnifiedCallbacks);
             self->unifiedFetchInFlight.store(false);
+
+            // Stale fetch: invalidateCache() ran while the worker was in flight
+            // (account/profile/locale switch). The result was computed with the OLD
+            // npsso/locale, and worse, the lib re-wrote the cache files AFTER the
+            // wipe. Never surface or persist it: wipe the cache again and restart
+            // the fetch for every waiting callback — the first restart spawns a
+            // fresh worker with current inputs, the rest coalesce onto it.
+            if (self->catalogGeneration != gen) {
+                const QByteArray staleCacheDir = self->cacheDirectory.toUtf8();
+                chiaki_cloudcatalog_invalidate_cache(staleCacheDir.constData());
+                qInfo() << "[CACHE] Discarding stale unified fetch (generation"
+                        << gen << "!=" << self->catalogGeneration << "); refetching";
+                if (cb.isCallable())
+                    self->fetchUnifiedCatalog(cb);
+                for (QJSValue &pcb : parked)
+                    if (pcb.isCallable())
+                        self->fetchUnifiedCatalog(pcb);
+                return;
+            }
 
             // Persist the locale the lib actually settled on (region detection now lives
             // entirely in libchiaki: it re-bases the locale on the account's Kamaji-session
@@ -697,6 +721,10 @@ QString CloudCatalogBackend::getGameLandscapeImageFromCache(const QString &servi
 
 void CloudCatalogBackend::invalidateCache()
 {
+    // Mark any in-flight unified fetch stale FIRST: its completion handler compares
+    // its snapshot against this counter and discards + restarts instead of serving
+    // (and re-persisting) a result computed with the pre-invalidation account/locale.
+    catalogGeneration++;
     // libchiaki owns every cache file and its versioned key (current + legacy), so
     // delegate to it. This is the single source of truth for cache naming and keeps
     // the client from drifting out of sync when the cache schema/version bumps.

--- a/ios/Pylux/Views/CloudPlayView.swift
+++ b/ios/Pylux/Views/CloudPlayView.swift
@@ -1,10 +1,37 @@
 // SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
 // Cloud Play UI - mirrors Android CloudPlayFragment.kt + CloudPlayViewModel.kt
 
+import Foundation
 import SwiftUI
 import os.log
 
 private let cloudUILog = OSLog(subsystem: "com.pylux.stream", category: "CloudPlayUI")
+
+/// Thread-safe cancel flag for cloud allocation: set on the main actor by the
+/// Cancel button, polled from libchiaki's provisioning worker thread through the
+/// isCancelled callback (a @MainActor property can't be read from that thread).
+final class AllocationCancelFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    func set() {
+        lock.lock()
+        value = true
+        lock.unlock()
+    }
+
+    func reset() {
+        lock.lock()
+        value = false
+        lock.unlock()
+    }
+
+    var isSet: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
 
 // MARK: - ViewModel (matches Android CloudPlayViewModel.kt)
 
@@ -49,6 +76,7 @@ final class CloudPlayViewModel: ObservableObject {
     @Published var allocationError: String?
     @Published var showPingTooHighDialog = false
     @Published var cloudSession: CloudStreamSession?
+    private let allocationCancelFlag = AllocationCancelFlag()
 
     private let catalogService = CloudCatalogService()
     private let streamingBackend = CloudStreamingBackend()
@@ -196,6 +224,7 @@ final class CloudPlayViewModel: ObservableObject {
         allocationError = nil
         showPingTooHighDialog = false
         cloudSession = nil
+        allocationCancelFlag.reset()
 
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self = self else { return }
@@ -204,7 +233,10 @@ final class CloudPlayViewModel: ObservableObject {
             let gameIdentifier = game.streamIdentifier
             let gameName = game.name
             let serviceType = game.streamServiceType
-            var cancelled = false
+            // Cancel Button -> cancelAllocation() -> this flag -> libchiaki's isCancelled
+            // poll aborts provisioning. Also gates every completion below so a cancelled
+            // allocation never launches the stream or flashes an error alert.
+            let cancelFlag = self.allocationCancelFlag
 
             do {
                 let session = try self.streamingBackend.startCompleteCloudSession(
@@ -221,26 +253,30 @@ final class CloudPlayViewModel: ObservableObject {
                             self.allocationProgress = msg
                         }
                     },
-                    isCancelled: { cancelled }
+                    isCancelled: { cancelFlag.isSet }
                 )
 
                 await MainActor.run {
                     self.allocating = false
+                    guard !cancelFlag.isSet else { return } // cancelled: never launch
                     self.cloudSession = session
                 }
             } catch let error as PsPlusSubscriptionError {
                 await MainActor.run {
                     self.allocating = false
+                    guard !cancelFlag.isSet else { return }
                     self.allocationError = error.message
                 }
             } catch is PingTimeoutError {
                 await MainActor.run {
                     self.allocating = false
+                    guard !cancelFlag.isSet else { return }
                     self.showPingTooHighDialog = true
                 }
             } catch {
                 await MainActor.run {
                     self.allocating = false
+                    guard !cancelFlag.isSet else { return }
                     self.allocationError = error.localizedDescription
                 }
             }
@@ -248,6 +284,7 @@ final class CloudPlayViewModel: ObservableObject {
     }
 
     func cancelAllocation() {
+        allocationCancelFlag.set() // aborts the in-flight libchiaki provisioning
         allocating = false
     }
 }

--- a/ios/Pylux/Views/CloudPlayView.swift
+++ b/ios/Pylux/Views/CloudPlayView.swift
@@ -20,12 +20,6 @@ final class AllocationCancelFlag: @unchecked Sendable {
         lock.unlock()
     }
 
-    func reset() {
-        lock.lock()
-        value = false
-        lock.unlock()
-    }
-
     var isSet: Bool {
         lock.lock()
         defer { lock.unlock() }
@@ -76,7 +70,11 @@ final class CloudPlayViewModel: ObservableObject {
     @Published var allocationError: String?
     @Published var showPingTooHighDialog = false
     @Published var cloudSession: CloudStreamSession?
-    private let allocationCancelFlag = AllocationCancelFlag()
+    // One instance PER allocation (fresh on each start), not one shared flag: a
+    // shared flag's reset-on-start would resurrect a just-cancelled allocation
+    // that hasn't hit its next isCancelled poll yet. Each allocation captures its
+    // own instance; cancel sets the current one.
+    private var allocationCancelFlag = AllocationCancelFlag()
 
     private let catalogService = CloudCatalogService()
     private let streamingBackend = CloudStreamingBackend()
@@ -224,7 +222,8 @@ final class CloudPlayViewModel: ObservableObject {
         allocationError = nil
         showPingTooHighDialog = false
         cloudSession = nil
-        allocationCancelFlag.reset()
+        let cancelFlag = AllocationCancelFlag()
+        allocationCancelFlag = cancelFlag
 
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self = self else { return }
@@ -233,10 +232,10 @@ final class CloudPlayViewModel: ObservableObject {
             let gameIdentifier = game.streamIdentifier
             let gameName = game.name
             let serviceType = game.streamServiceType
-            // Cancel Button -> cancelAllocation() -> this flag -> libchiaki's isCancelled
-            // poll aborts provisioning. Also gates every completion below so a cancelled
-            // allocation never launches the stream or flashes an error alert.
-            let cancelFlag = self.allocationCancelFlag
+            // cancelFlag (this allocation's own instance, captured above): Cancel Button
+            // -> cancelAllocation() -> flag -> libchiaki's isCancelled poll aborts
+            // provisioning. Also gates every completion below so a cancelled allocation
+            // never launches the stream or flashes an error alert.
 
             do {
                 let session = try self.streamingBackend.startCompleteCloudSession(

--- a/lib/src/cloudcatalog_merge.c
+++ b/lib/src/cloudcatalog_merge.c
@@ -213,8 +213,22 @@ const char *cc_stable_key(const char *product_id, char *out, size_t out_sz)
 	int ntok = 0;
 	char buf[256];
 	snprintf(buf, sizeof(buf), "%s", product_id);
-	for(char *tok = strtok(buf, "-_"); tok && ntok < 16; tok = strtok(NULL, "-_"))
-		snprintf(tokens[ntok++], 64, "%s", tok);
+	// Manual scan, NOT strtok: strtok's process-wide save-pointer is also used by
+	// holepunch.c on session threads, and a catalog fetch can run concurrently with
+	// a remote-play connect — the two parses would cross-corrupt.
+	for(char *p = buf; *p && ntok < 16;)
+	{
+		while(*p == '-' || *p == '_')
+			p++;
+		if(!*p)
+			break;
+		char *start = p;
+		while(*p && *p != '-' && *p != '_')
+			p++;
+		if(*p)
+			*p++ = 0;
+		snprintf(tokens[ntok++], 64, "%s", start);
+	}
 	if(ntok < 2)
 		return out;
 	ntok--; // drop last token

--- a/lib/src/cloudcatalog_unified.c
+++ b/lib/src/cloudcatalog_unified.c
@@ -245,6 +245,12 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 
 	// 3. imagic (cache, then network with locale fallback).
 	struct json_object *browse = NULL, *supplement = NULL, *aliases = NULL;
+	// True only when the PS5 browse universe is known-complete (v6 cache hit — its
+	// write was already gated on all-ps5-list — or a fresh fetch where all-ps5-list
+	// succeeded). Gates the unified cache write below: a browse missing its main
+	// list would otherwise cache a catalog whose streamability gate silently drops
+	// owned PS5 games for the whole TTL.
+	bool browse_complete = false;
 	char settled[16];
 	snprintf(settled, sizeof(settled), "%s", effective_locale);
 
@@ -274,6 +280,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 		if(*cl)
 			snprintf(settled, sizeof(settled), "%s", cl);
 		json_object_put(v6);
+		browse_complete = true;
 	}
 	else
 	{
@@ -284,6 +291,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 			supplement = ir.supplement; ir.supplement = NULL;
 			aliases = ir.aliases; ir.aliases = NULL;
 			snprintf(settled, sizeof(settled), "%s", ir.settled_locale);
+			browse_complete = ir.all_ps5_list_succeeded;
 			if(ir.all_ps5_list_succeeded)
 				write_v6_cache(log, cache_dir, settled, browse, supplement, aliases);
 			cc_imagic_result_fini(&ir);
@@ -364,10 +372,10 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 	in.warning = warning;
 	struct json_object *env = cc_assemble_unified_catalog(log, &in);
 
-	// 7. cache write guard (non-empty + not auth error).
+	// 7. cache write guard (non-empty + not auth error + both sources complete).
 	struct json_object *games = cc_json_arr(env, "games");
 	int total = games ? (int)json_object_array_length(games) : 0;
-	if(total > 0 && !auth_error && apollo_complete)
+	if(total > 0 && !auth_error && apollo_complete && browse_complete)
 		cc_cache_write(log, cache_dir, "unified_catalog_v3", env);
 
 	ChiakiErrorCode e = finish_ok(out, env);

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -642,7 +642,11 @@ static int gk_cmp_rtt(const void *a, const void *b)
 // sequential pinging made "Pinging Datacenters" take far too long.
 typedef struct
 {
-	ChiakiLog *log;
+	// By-value copy of the caller's ChiakiLog, NOT a pointer to it: an abandoned
+	// (detached) thread outlives chiaki_cloud_provision_session, and the Qt/iOS
+	// callers pass a stack-local log that is gone by then. The copy lives as long
+	// as the job (freed via the handoff exchange), so late logging stays valid.
+	ChiakiLog log;
 	char *name, *ip, *session_key, *service_type; // strdup'd — owned by the job
 	int port, bw;
 	int64_t rtt_us; uint32_t mtu_in, mtu_out; bool ok;
@@ -661,7 +665,7 @@ static void *gk_ping_thread(void *arg)
 {
 	GkPingJob *j = (GkPingJob *)arg;
 	j->rtt_us = -1; j->mtu_in = 0; j->mtu_out = 0;
-	cc_ping_datacenter(j->log, j->ip, j->port, j->session_key, j->service_type,
+	cc_ping_datacenter(&j->log, j->ip, j->port, j->session_key, j->service_type,
 		&j->rtt_us, &j->mtu_in, &j->mtu_out);
 	j->ok = (j->rtt_us > 0);
 	atomic_store(&j->done, 1);
@@ -795,7 +799,8 @@ static ChiakiErrorCode gk_step11_datacenters(GaikaiCtx *c)
 					cc_json_int(dc, "maxBandwidth"), false));
 				continue;
 			}
-			j->log = c->log;
+			if(c->log)
+				j->log = *c->log; // copy, see GkPingJob.log (calloc'd zero = silent if no log)
 			j->name = strdup(cc_json_str(dc, "dataCenter"));
 			j->ip   = strdup(cc_json_str(dc, "publicIp"));
 			j->port = cc_json_int(dc, "port");


### PR DESCRIPTION
Fixes for the highest-confidence findings from the pre-merge review of #25 (release/beta → master). All changes are deliberately minimal and fail-safe; findings that would have required altering device-verified behavior (chord timing, iOS teardown ordering) were intentionally left out.

## Fixes

**lib: datacenter-ping thread UAF on the caller's stack ChiakiLog** — ping threads abandoned at the 15 s deadline kept logging through the caller's `ChiakiLog*`; the Qt and iOS callers pass a stack-local log that is freed when `chiaki_cloud_provision_session` returns (senkusha's connect timeout can fire ~30 s later). `GkPingJob` now embeds a by-value copy, which the existing handoff-exchange protocol already keeps alive for the thread's whole life. Trigger was any hung ping (UDP blocked, one dead datacenter) or a user cancel during "Pinging Datacenters".

**lib: `cc_stable_key` no longer uses `strtok`** — its process-wide save-pointer is shared with `holepunch.c`'s session-thread parsing; a catalog fetch concurrent with a remote-play connect would cross-corrupt both. Replaced with a self-contained scan (identical semantics, covered by the existing unit tests) rather than `strtok_r`, which isn't guaranteed on every Windows toolchain.

**lib: unified catalog cache write now requires a complete PS5 browse list** — one transient failure of the imagic `all-ps5-list` request cached a catalog whose streamability gate silently dropped owned PS5 games for the whole 24 h TTL. The guard now also requires browse completeness (v6 cache hit, or fresh fetch with `all-ps5-list` OK). Fail-safe: worst case is a refetch on next launch.

**gui: in-flight unified fetches are discarded on cache invalidation** — the fetch coalescing had no staleness notion, so switching account/profile mid-fetch served the previous account's catalog to the post-invalidation reload, and the old worker re-persisted it to the freshly wiped cache (survives restarts, up to 24 h). `invalidateCache()` now bumps a generation counter; a stale completion wipes the cache again and restarts the fetch for all waiting callbacks.

**ios: the cloud-allocation Cancel button now cancels** — `isCancelled` captured a local var nothing ever set; cancel only hid the overlay while provisioning kept running, allocated a server slot, and then force-launched the stream. The button now sets a lock-protected flag polled by libchiaki's worker, and every completion is gated on it (no launch, no stray error alert).

## Verification

- lib unit suite: **116/116 pass** (includes the `cc_stable_key` cases exercising the new tokenizer)
- Qt GUI: full compile clean (macOS arm64)
- iOS: full `xcodebuild` compile clean (no new warnings; existing actor-isolation warnings untouched)
- Not device-retested by design — each change is scoped so its failure mode is the pre-fix behavior or a cache refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)