### PR TITLE
Pin Flatpak manifest to 2.11.1 beta (2448f573)

### DIFF
--- a/scripts/flatpak/io.github.ForWard_Technologies_LLC.Pylux.yml
+++ b/scripts/flatpak/io.github.ForWard_Technologies_LLC.Pylux.yml
@@ -129,4 +129,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/ForWard-Technologies-LLC/Pylux.git
-        commit: 43edf15d16e5a08065712ca23a733f75eb1272a0
+        commit: 2448f573cc2055d1e01fef251f6296590762fdb6


### PR DESCRIPTION
The manifest still pinned 43edf15d — the 2.11.0 metainfo commit, which predates both PR #25 review-fix rounds (#34, #35). This advances the pin to the current `release/beta` tip (2448f573) so Flathub builds carry all 21 hardening fixes (UAF on profile switch, cancel-flow fixes, cache/Windows fixes, etc.).

One-line change; no code impact outside the Flatpak build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)