### PR TITLE
PR #25 review round 3: session-lifetime, cancellation, and cache-poisoning fixes

### DIFF
--- a/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
+++ b/android/app/src/main/java/com/metallic/chiaki/main/CloudPlayFragment.kt
@@ -43,6 +43,7 @@ import com.metallic.chiaki.cloudplay.model.CloudGame
 import com.metallic.chiaki.common.Preferences
 import com.metallic.chiaki.common.ext.viewModelFactory
 import com.pylux.stream.databinding.FragmentCloudPlayBinding
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 class CloudPlayFragment : Fragment()
@@ -1090,6 +1091,14 @@ class CloudPlayFragment : Fragment()
 			try
 			{
 				val backend = CloudStreamingBackend(requireContext(), viewModel.preferences)
+				// Owned-PSNOW fast-path, gated like Qt's getOwnedPsnowEntitlement: only owned
+				// PSNOW rows carry a pre-resolved streaming entitlement. Passing entitlementId
+				// unconditionally worked only because unowned rows currently normalize to an
+				// empty one -- if that upstream invariant ever breaks, every unowned launch
+				// would take the fast path and hard-fail (the lib's one-shot recovery only
+				// catches the noGameForEntitlement error shape).
+				val ownedFastPath = game.isOwned && game.streamServiceType == "psnow" &&
+					game.entitlementId.isNotEmpty()
 				// Stream routing is precomputed by libchiaki: streamServiceType picks the endpoint
 				// (psnow/Kamaji vs pscloud/cronos) and streamIdentifier is the exact id to launch.
 				val result = backend.startCompleteCloudSession(
@@ -1097,10 +1106,8 @@ class CloudPlayFragment : Fragment()
 					gameIdentifier = game.streamIdentifier,
 					gameName = game.name,
 					npssoToken = npssoToken,
-					// Owned-PSNOW fast-path: the catalog's pre-resolved streaming entitlement (empty
-					// for unowned titles -> normal full flow). Only used by the PSNOW path.
-					ownedEntitlementId = game.entitlementId,
-					ownedPlatform = game.platform,
+					ownedEntitlementId = if (ownedFastPath) game.entitlementId else "",
+					ownedPlatform = if (ownedFastPath) game.platform else "",
 					onProgress = { message ->
 						activity?.runOnUiThread {
 							allocationProgressTextView?.text = message
@@ -1122,15 +1129,19 @@ class CloudPlayFragment : Fragment()
 				}
 				
 				result.onFailure { error ->
-					requireActivity().runOnUiThread {
-						requireActivity().requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+					// The fragment can be destroyed while the (non-cancellable) JNI call
+					// runs; requireActivity() would throw on the detached fragment. No
+					// activity also means no UI to clean up or show dialogs on.
+					val act = activity ?: return@launch
+					act.runOnUiThread {
+						act.requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
 						savedOrientation = -1
 						allocationProgressDialog?.dismiss()
 						allocationProgressDialog = null
 						allocationProgressTextView = null
 						allocationGameImageView = null
 					}
-					
+
 					if (allocationCancelled) return@launch
 					
 					Log.e(TAG, "Cloud session failed: ${error.message}")
@@ -1162,17 +1173,27 @@ class CloudPlayFragment : Fragment()
 					}
 				}
 			}
+			catch (e: CancellationException)
+			{
+				// lifecycleScope was cancelled (fragment destroyed / user left) while
+				// the JNI call was in flight: rethrow instead of running failure UI on
+				// a dead fragment -- catching this via Exception below is what used to
+				// crash in requireActivity().
+				throw e
+			}
 			catch (e: Exception)
 			{
-				requireActivity().runOnUiThread {
-					requireActivity().requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+				// Same detachment guard as onFailure above.
+				val act = activity ?: return@launch
+				act.runOnUiThread {
+					act.requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
 					savedOrientation = -1
 					allocationProgressDialog?.dismiss()
 					allocationProgressDialog = null
 					allocationProgressTextView = null
 					allocationGameImageView = null
 				}
-				
+
 				if (allocationCancelled) return@launch
 				
 				Log.e(TAG, "Exception starting cloud session", e)

--- a/gui/src/cloudcatalogbackend.cpp
+++ b/gui/src/cloudcatalogbackend.cpp
@@ -263,7 +263,10 @@ void CloudCatalogBackend::fetchUnifiedCatalog(const QJSValue &callback)
         // QJSValue must be invoked on the engine (main) thread. Route through qApp so
         // the callback is fetched and invoked on the GUI thread even if `self` is
         // destroyed before the worker finishes.
-        QMetaObject::invokeMethod(qApp, [self, reqId, gen, success, message, json]() mutable {
+        QCoreApplication *app = QCoreApplication::instance();
+        if (!app)
+            return; // user quit mid-fetch: the app object is gone, nothing to deliver to
+        QMetaObject::invokeMethod(app, [self, reqId, gen, success, message, json]() mutable {
             if (!self)
                 return; // backend destroyed while the worker ran
             const QJSValue cb = self->pending_callbacks.take(reqId);

--- a/gui/src/cloudstreamingbackend.cpp
+++ b/gui/src/cloudstreamingbackend.cpp
@@ -203,7 +203,10 @@ void CloudStreamingBackend::continueCloudSessionAfterAuth(QString serviceType, Q
         const QString dcPings = res.datacenter_pings ? QString::fromUtf8(res.datacenter_pings) : QString();
         chiaki_cloud_provision_result_fini(&res);
 
-        QMetaObject::invokeMethod(qApp, [self, reqId, success, attrPassed, serviceTypeStr, serverIp, serverPort,
+        QCoreApplication *app = QCoreApplication::instance();
+        if (!app)
+            return; // user quit mid-provision: the app object is gone, nothing to deliver to
+        QMetaObject::invokeMethod(app, [self, reqId, success, attrPassed, serviceTypeStr, serverIp, serverPort,
                                          handshakeKey, launchSpec, sessionId, wrap, mtuIn, mtuOut, rttUs, errMsg, dcPings]() mutable {
             if (!self)
                 return; // backend destroyed while the worker ran
@@ -441,7 +444,10 @@ void CloudStreamingBackend::provisionProgressThunk(const char *stage, void *user
     // backend with a shorter lifetime.
     QPointer<CloudStreamingBackend> self = *holder;
     const QString s = QString::fromUtf8(stage);
-    QMetaObject::invokeMethod(qApp, [self, s]() {
+    QCoreApplication *app = QCoreApplication::instance();
+    if (!app)
+        return; // user quit mid-provision: the app object is gone, nothing to deliver to
+    QMetaObject::invokeMethod(app, [self, s]() {
         if (self)
             self->setAllocationProgress(s);
     }, Qt::QueuedConnection);

--- a/gui/src/qml/StreamView.qml
+++ b/gui/src/qml/StreamView.qml
@@ -364,7 +364,9 @@ Item {
                 visible: Chiaki.session
                 Label {
                     anchors { right: parent.left; baseline: parent.baseline; rightMargin: 5 }
-                    text: visible ? Chiaki.session.measuredBitrate.toFixed(1) : ""
+                    // Guard the session itself, not just visibility: this binding can
+                    // re-evaluate during teardown before the parent's visible updates.
+                    text: Chiaki.session ? Chiaki.session.measuredBitrate.toFixed(1) : ""
                     color: Material.accent
                     font.bold: true
                     font.pixelSize: 28
@@ -379,7 +381,8 @@ Item {
                 visible: Chiaki.session
                 Label {
                     anchors { right: parent.left; baseline: parent.baseline; rightMargin: 5 }
-                    text: parent.visible ? "%1<font size=\"1\">%</font>".arg((Chiaki.session.averagePacketLoss * 100).toFixed(1)) : ""
+                    // Same teardown guard as the Mbps label above.
+                    text: Chiaki.session ? "%1<font size=\"1\">%</font>".arg((Chiaki.session.averagePacketLoss * 100).toFixed(1)) : ""
                     font.bold: true
                     color: "#ef9a9a" // Material.Red
                     font.pixelSize: 18

--- a/ios/Pylux/Bridge/HolepunchBridge.m
+++ b/ios/Pylux/Bridge/HolepunchBridge.m
@@ -169,17 +169,26 @@ static void ensure_log_init(void) {
 
 - (void)markConsumed {
     // The native chiaki session now owns the holepunch session pointer.
-    // Clear our reference so dealloc/fini won't double-free.
-    _session = NULL;
-    _valid = NO;
+    // Clear our reference so dealloc/fini won't double-free. @synchronized because
+    // the consuming thread (session create worker) races shutdown()'s deferred fini.
+    @synchronized (self) {
+        _session = NULL;
+        _valid = NO;
+    }
     os_log(s_hp_log, "Holepunch session marked as consumed by native session");
 }
 
 - (void)fini {
-    if (_valid && _session) {
-        chiaki_holepunch_session_fini(_session);
-        _session = NULL;
-        _valid = NO;
+    ChiakiHolepunchSession session = NULL;
+    @synchronized (self) {
+        if (_valid && _session) {
+            session = _session;
+            _session = NULL;
+            _valid = NO;
+        }
+    }
+    if (session) {
+        chiaki_holepunch_session_fini(session);
         os_log(s_hp_log, "Holepunch session finalized");
     }
 }

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -83,6 +83,13 @@ final class StreamSession: ObservableObject {
     /// landing in that window would let the freshly created session start and stream
     /// with no owner left to stop it.
     private var isShutDown = false
+    // Number of PSN threads currently inside chiaki_session_bridge_create (which can
+    // block for seconds holding the holepunch pointer). While nonzero, shutdown() must
+    // NOT fini the holepunch session — the create thread owns it and finis it via
+    // its own failure path or the unpublished-session free. A counter, not a Bool, so
+    // a cancel-and-reconnect overlap can't let the old create's exit unguard the new
+    // create's window. Main-actor only.
+    private var psnCreatesInFlight = 0
     /// Holepunch session for PSN connections (kept alive for session lifetime)
     private var holepunchSession: PyluxHolepunchSession?
     /// Chiaki `CHIAKI_EVENT_RUMBLE` → Core Haptics (when `rumbleEnabled`).
@@ -203,9 +210,15 @@ final class StreamSession: ObservableObject {
         } else {
             let hpSession = holepunchSession
             holepunchSession = nil
-            DispatchQueue.global(qos: .userInitiated).async { [hpSession] in
-                hpSession?.fini()
+            if psnCreatesInFlight == 0 {
+                DispatchQueue.global(qos: .userInitiated).async { [hpSession] in
+                    hpSession?.fini()
+                }
             }
+            // else: the PSN create thread is inside chiaki_session_bridge_create with
+            // this pointer right now — fini-ing it here would free it out from under
+            // the create (and double-free via chiaki_session_fini later). That thread
+            // sees isShutDown at its publish gate and finis via the unpublished free.
             eventReceiver?.invalidate()
         }
         eventReceiver = nil
@@ -639,6 +652,23 @@ final class StreamSession: ObservableObject {
     // MARK: - Synchronous session creation for PSN connections (runs on dedicated thread)
 
     private func createAndStartSessionSync(connectInfo: StreamConnectInfo, holepunchPtr: UInt, hpSession: PyluxHolepunchSession) {
+        // Claim the create window on main BEFORE the blocking create: while
+        // psnCreatesInFlight is nonzero, shutdown() leaves the holepunch pointer's
+        // ownership with this thread instead of fini-ing it out from under the
+        // create call (which would be a use-after-free plus a later double-fini).
+        let mayCreate = DispatchQueue.main.sync { [weak self] () -> Bool in
+            guard let self, !self.isShutDown else { return false }
+            self.psnCreatesInFlight += 1
+            return true
+        }
+        if !mayCreate {
+            // shutdown() already ran; the flag was never set, so its else-branch
+            // fini'd (or queued the fini of) the wrapper. fini here is an
+            // idempotent no-op either way (@synchronized), keeping the fini single.
+            hpSession.fini()
+            return
+        }
+
         let receiver = makeSessionEventReceiver()
 
         let decoder = PyluxVideoDecoder(
@@ -690,8 +720,9 @@ final class StreamSession: ObservableObject {
         guard let ref = ref else {
             os_log(.default, log: sessionLog, "%{public}s", "[StreamSession] Failed to create session: \(err)")
             receiver.invalidate() // the create call already took the self-retain
-            hpSession.fini()
+            hpSession.fini() // create failed -> the session never took ownership; single fini here
             DispatchQueue.main.async { [weak self] in
+                self?.psnCreatesInFlight -= 1
                 self?.connectionPhase = ""
                 self?.state = .createError(errorCode: err != 0 ? err : 1, message: nil)
             }
@@ -714,7 +745,9 @@ final class StreamSession: ObservableObject {
         // started and nobody owns it, so free it here instead of letting it stream
         // unowned (same guard as createAndStartSession's async path).
         let published = DispatchQueue.main.sync { [weak self] () -> Bool in
-            guard let self, !self.isShutDown else { return false }
+            guard let self else { return false }
+            self.psnCreatesInFlight -= 1 // create returned; ownership decided below
+            guard !self.isShutDown else { return false }
             self.holepunchSession = nil // claim already consumed above
             self.sessionRef = ref
             self.videoDecoder = decoder
@@ -760,11 +793,12 @@ final class StreamSession: ObservableObject {
         let joinRef = ref
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             _ = chiaki_session_bridge_join(joinRef)
-            chiaki_session_bridge_free(joinRef)
-            // Release THIS session's receiver directly (idempotent): after join+free no
-            // callback can fire, and self.eventReceiver may already point elsewhere.
-            receiver.invalidate()
-            Task { @MainActor [weak self] in
+            // Retire the published refs BEFORE freeing, same as the async path's join
+            // task: on a console-initiated quit sessionRef is still set here, and the
+            // 1 Hz metrics poll / controller callbacks on main could otherwise reach
+            // the freed session. Main is serial: once this sync block returns, any
+            // reader that grabbed the ref has already finished its call.
+            DispatchQueue.main.sync { [weak self] in
                 self?.rumbleFeedback?.shutdown()
                 self?.rumbleFeedback = nil
                 if self?.sessionRef == nil {
@@ -781,6 +815,10 @@ final class StreamSession: ObservableObject {
                     }
                 }
             }
+            chiaki_session_bridge_free(joinRef)
+            // Release THIS session's receiver directly (idempotent): after join+free no
+            // callback can fire, and self.eventReceiver may already point elsewhere.
+            receiver.invalidate()
         }
     }
 

--- a/ios/Pylux/Services/StreamSession.swift
+++ b/ios/Pylux/Services/StreamSession.swift
@@ -586,8 +586,9 @@ final class StreamSession: ObservableObject {
 
         let startErr = chiaki_session_bridge_start(ref)
         if startErr != 0 {
-            chiaki_session_bridge_free(ref)
-            receiver.invalidate() // matches the sync path; without it each failed start leaks a receiver
+            // Retire the published refs BEFORE freeing: metrics() and the controller
+            // callback read sessionRef on the main actor, so clearing there first
+            // (main is serial) means nothing can reach the session once free runs.
             await MainActor.run { [weak self] in
                 self?.connectionPhase = ""
                 self?.sessionRef = nil
@@ -595,6 +596,8 @@ final class StreamSession: ObservableObject {
                 self?.eventReceiver = nil
                 self?.state = .createError(errorCode: startErr, message: nil)
             }
+            chiaki_session_bridge_free(ref)
+            receiver.invalidate() // matches the sync path; without it each failed start leaks a receiver
             return
         }
 
@@ -603,11 +606,12 @@ final class StreamSession: ObservableObject {
         let joinRef = ref
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             _ = chiaki_session_bridge_join(joinRef)
-            chiaki_session_bridge_free(joinRef)
-            // Release THIS session's receiver directly (idempotent): after join+free no
-            // callback can fire, and self.eventReceiver may already point elsewhere.
-            receiver.invalidate()
-            Task { @MainActor [weak self] in
+            // Retire the published refs BEFORE freeing (previously free ran first,
+            // leaving a window where the 1 Hz metrics poll or a controller-state
+            // callback on main could reach the freed session on a console-initiated
+            // quit). Main is serial: once this sync block returns, any reader that
+            // grabbed the ref has already finished its call.
+            DispatchQueue.main.sync { [weak self] in
                 self?.rumbleFeedback?.shutdown()
                 self?.rumbleFeedback = nil
                 if self?.sessionRef == nil {
@@ -625,6 +629,10 @@ final class StreamSession: ObservableObject {
                     }
                 }
             }
+            chiaki_session_bridge_free(joinRef)
+            // Release THIS session's receiver directly (idempotent): after join+free no
+            // callback can fire, and self.eventReceiver may already point elsewhere.
+            receiver.invalidate()
         }
     }
 
@@ -696,34 +704,52 @@ final class StreamSession: ObservableObject {
         // controller is (or later becomes) attached.
         chiaki_session_bridge_enable_haptics_rumble(ref)
 
-        // Native session owns holepunch pointer now
-        DispatchQueue.main.async { [weak self] in
-            self?.holepunchSession?.markConsumed()
-            self?.holepunchSession = nil
-            self?.sessionRef = ref
-            self?.videoDecoder = decoder
-            self?.eventReceiver = receiver
+        // The native session owns the holepunch pointer from the moment create
+        // succeeded: consume the wrapper's claim NOW, on this thread, so a shutdown()
+        // landing before the publish below can't fini a pointer the session owns.
+        hpSession.markConsumed()
+
+        // Publish, unless shutdown() ran while the session was being created (the
+        // create call above can block for seconds): then the session was never
+        // started and nobody owns it, so free it here instead of letting it stream
+        // unowned (same guard as createAndStartSession's async path).
+        let published = DispatchQueue.main.sync { [weak self] () -> Bool in
+            guard let self, !self.isShutDown else { return false }
+            self.holepunchSession = nil // claim already consumed above
+            self.sessionRef = ref
+            self.videoDecoder = decoder
+            self.eventReceiver = receiver
             // Attach stored view immediately (matches Android: setSurface when session created)
-            if let view = self?.pendingVideoView, let layer = view.videoDisplayLayer {
+            if let view = self.pendingVideoView, let layer = view.videoDisplayLayer {
                 let b = layer.bounds
                 os_log(.default, log: sessionLog, "[StreamSession] PSN: attaching stored view layer.bounds=%.0fx%.0f", b.width, b.height)
                 decoder.setDisplayLayer(layer)
             } else {
-                os_log(.default, log: sessionLog, "[StreamSession] PSN: no stored view (pending=%d)", self?.pendingVideoView != nil ? 1 : 0)
+                os_log(.default, log: sessionLog, "[StreamSession] PSN: no stored view (pending=%d)", self.pendingVideoView != nil ? 1 : 0)
             }
+            return true
+        }
+        if !published {
+            os_log(.default, log: sessionLog, "%{public}s", "[StreamSession] PSN: shut down during session creation; discarding unstarted session")
+            chiaki_session_bridge_free(ref) // never started -> free directly, no join needed (also finis the consumed holepunch session)
+            receiver.invalidate()
+            return
         }
 
         chiaki_session_bridge_set_video_sample_cb(ref, PyluxVideoDecoderVideoSampleCallback, Unmanaged.passUnretained(decoder).toOpaque())
 
         let startErr = chiaki_session_bridge_start(ref)
         if startErr != 0 {
-            chiaki_session_bridge_free(ref)
-            receiver.invalidate()
-            DispatchQueue.main.async { [weak self] in
+            // Retire the published refs BEFORE freeing: metrics() and the controller
+            // callback read sessionRef on the main thread, so clearing there first
+            // (main is serial) means nothing can reach the session once free runs.
+            DispatchQueue.main.sync { [weak self] in
                 self?.connectionPhase = ""
                 self?.sessionRef = nil; self?.videoDecoder = nil; self?.eventReceiver = nil
                 self?.state = .createError(errorCode: startErr, message: nil)
             }
+            chiaki_session_bridge_free(ref)
+            receiver.invalidate()
             return
         }
 

--- a/ios/Pylux/Views/CachedAsyncImage.swift
+++ b/ios/Pylux/Views/CachedAsyncImage.swift
@@ -91,7 +91,12 @@ struct CachedAsyncImage<Content: View>: View {
                     return
                 }
                 if case .success = phase { phase = .empty }
-                if let img = await CloudImageLoader.shared.image(for: url) {
+                let img = await CloudImageLoader.shared.image(for: url)
+                // The shared download deliberately outlives .task(id:) cancellation (see
+                // above), so this continuation can resume for a URL the view no longer
+                // shows — don't let the stale result overwrite the newer task's phase.
+                guard !Task.isCancelled else { return }
+                if let img {
                     phase = .success(Image(uiImage: img))
                 } else {
                     phase = .failure(URLError(.cannotDecodeContentData))

--- a/lib/src/cloudcatalog_cache.c
+++ b/lib/src/cloudcatalog_cache.c
@@ -7,6 +7,7 @@
 #include "cloudcatalog_internal.h"
 
 #include <errno.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -146,8 +147,12 @@ ChiakiErrorCode cc_cache_write(ChiakiLog *log, const char *cache_dir, const char
 
 	// Write to a unique temp file then atomically rename, so a concurrent reader
 	// (or an overlapping writer on the same cache dir) never sees a torn file.
-	char tmp[1056];
-	snprintf(tmp, sizeof(tmp), "%s.tmp.%ld", path, (long)cc_getpid());
+	// The pid alone is not unique within this process — two worker threads writing
+	// the same key would interleave into one temp file — so add a per-call counter.
+	static atomic_uint tmp_seq;
+	char tmp[1088];
+	snprintf(tmp, sizeof(tmp), "%s.tmp.%ld.%u", path, (long)cc_getpid(),
+		atomic_fetch_add(&tmp_seq, 1));
 
 	FILE *f = fopen(tmp, "wb");
 	if(!f)
@@ -157,8 +162,9 @@ ChiakiErrorCode cc_cache_write(ChiakiLog *log, const char *cache_dir, const char
 	}
 	size_t len = strlen(json);
 	size_t wr = fwrite(json, 1, len, f);
-	fclose(f);
-	if(wr != len)
+	// fclose flushes stdio's buffer, so a full disk can first surface here — treat
+	// a failed close like a short write or we'd rename a truncated file into place.
+	if(fclose(f) != 0 || wr != len)
 	{
 		remove(tmp);
 		return CHIAKI_ERR_UNKNOWN;

--- a/lib/src/cloudcatalog_fetch.c
+++ b/lib/src/cloudcatalog_fetch.c
@@ -54,6 +54,8 @@ static char *url_encode(const char *s)
 }
 
 // Extract value of "key=" from a URL/query/fragment up to '&'. Returns true if found.
+// The key must start a parameter (begin-of-string or after ?/&/#) so e.g. "code="
+// doesn't match inside "error_code=" on OAuth error redirects.
 static bool extract_param(const char *url, const char *key, char *out, size_t out_sz)
 {
 	out[0] = 0;
@@ -62,6 +64,8 @@ static bool extract_param(const char *url, const char *key, char *out, size_t ou
 	char pat[64];
 	snprintf(pat, sizeof(pat), "%s=", key);
 	const char *p = strstr(url, pat);
+	while(p && !(p == url || p[-1] == '?' || p[-1] == '&' || p[-1] == '#'))
+		p = strstr(p + 1, pat);
 	if(!p)
 		return false;
 	p += strlen(pat);
@@ -151,6 +155,8 @@ static CCNativeResult psnow_oauth(ChiakiLog *log, const char *npsso, const char 
 		if(extract_param(resp.redirect_url, "code", out_code, code_sz))
 			result = CC_NATIVE_OK;
 	}
+	else if(resp.status_code >= 500)
+		result = CC_NATIVE_FATAL; // server blip says nothing about the token (parity with psnow_stores)
 	cc_http_response_fini(&resp);
 	return result;
 }
@@ -209,6 +215,8 @@ static CCNativeResult psnow_session(ChiakiLog *log, const char *code, const char
 		if(obj)
 			json_object_put(obj);
 	}
+	else if(resp.status_code >= 500)
+		result = CC_NATIVE_FATAL; // server blip says nothing about the token (parity with psnow_stores)
 	cc_http_response_fini(&resp);
 	return result;
 }
@@ -542,7 +550,7 @@ struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account
 			CHIAKI_LOGW(log, "[UNIFIED] APOLLOROOT fallback page at start=%d unparseable; list incomplete", start);
 			break;
 		}
-		if(total < 0)
+		if(total < 0 && cc_json_has(obj, "total_results"))
 			total = cc_json_int(obj, "total_results");
 		int product_count = 0;
 		struct json_object *links = cc_json_arr(obj, "links");
@@ -565,8 +573,27 @@ struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account
 		}
 		json_object_put(obj);
 		start += 100;
-		if(product_count <= 0 || (total >= 0 && start >= total))
+		if(total >= 0 && start >= total)
+			break; // server-confirmed end of list
+		if(product_count <= 0)
+		{
+			// Ran dry before the declared total, or the server never sent
+			// total_results at all (schema drift): either way we can't confirm
+			// completeness, so serve what we have but don't let it cache.
+			if(out_complete)
+				*out_complete = false;
+			CHIAKI_LOGW(log, "[UNIFIED] APOLLOROOT fallback ended at start=%d without a confirmed total; list incomplete", start - 100);
 			break;
+		}
+		if(start >= 10000)
+		{
+			// Hard cap so a server that keeps returning products (with no usable
+			// total) can't spin this loop forever.
+			if(out_complete)
+				*out_complete = false;
+			CHIAKI_LOGW(log, "[UNIFIED] APOLLOROOT fallback page cap hit at start=%d; list incomplete", start);
+			break;
+		}
 	}
 	CHIAKI_LOGI(log, "[UNIFIED] APOLLOROOT fallback: %d titles", (int)json_object_array_length(games));
 	return games;
@@ -791,6 +818,8 @@ static CCOwnedResult owned_oauth(ChiakiLog *log, const char *npsso, char *out_to
 		else if(extract_param(resp.redirect_url, "access_token", out_token, tok_sz))
 			result = CC_OWNED_OK;
 	}
+	else if(resp.status_code >= 500)
+		result = CC_OWNED_ERROR; // server blip says nothing about the token; don't flag the session expired
 	cc_http_response_fini(&resp);
 	return result;
 }

--- a/lib/src/cloudcatalog_unified.c
+++ b/lib/src/cloudcatalog_unified.c
@@ -330,6 +330,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 	}
 
 	// 4. owned entitlements (skip on missing/expired session).
+	bool owned_complete = true;
 	struct json_object *owned = NULL, *components = NULL;
 	if(*npsso && !auth_error)
 	{
@@ -353,6 +354,15 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 			{
 				auth_error = true;
 				warning = WARNING_EXPIRED;
+			}
+			else
+			{
+				// Transient commerce-API failure: serve this session without
+				// ownership, but don't cache the degraded catalog (same rule as
+				// apollo_complete / browse_complete) — otherwise one 5xx hides
+				// the user's whole owned library for the full cache TTL.
+				owned_complete = false;
+				CHIAKI_LOGW(log, "[CLOUDCATALOG] owned entitlements fetch failed; catalog will not be cached");
 			}
 		}
 	}
@@ -380,10 +390,10 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 	in.warning = warning;
 	struct json_object *env = cc_assemble_unified_catalog(log, &in);
 
-	// 7. cache write guard (non-empty + not auth error + both sources complete).
+	// 7. cache write guard (non-empty + not auth error + all three sources complete).
 	struct json_object *games = cc_json_arr(env, "games");
 	int total = games ? (int)json_object_array_length(games) : 0;
-	if(total > 0 && !auth_error && apollo_complete && browse_complete)
+	if(total > 0 && !auth_error && apollo_complete && browse_complete && owned_complete)
 		cc_cache_write(log, cache_dir, "unified_catalog_v3", env);
 
 	ChiakiErrorCode e = finish_ok(out, env);

--- a/lib/src/cloudsession.c
+++ b/lib/src/cloudsession.c
@@ -106,6 +106,11 @@ static ChiakiErrorCode cc_authorize_check(ChiakiLog *log,
 	return CHIAKI_ERR_UNKNOWN;
 }
 
+static bool cp_cancelled(const ChiakiCloudProvisionConfig *cfg)
+{
+	return cfg->is_cancelled && cfg->is_cancelled(cfg->user);
+}
+
 // One provisioning attempt: PSNOW resolves via Kamaji then allocates via Gaikai;
 // PSCLOUD allocates directly (game_identifier is already the PS5 entitlementId).
 static ChiakiErrorCode provision_once(ChiakiLog *log,
@@ -160,6 +165,14 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloud_provision_session(
 	#undef CC_NZ
 	cfg = &c;
 
+	// Cancelled before any work (e.g. the user backed out while the platform was
+	// still spinning up the worker): return without touching the network.
+	if(cp_cancelled(cfg))
+	{
+		out->err = CHIAKI_ERR_CANCELED;
+		return out->err;
+	}
+
 	// One shared client device uid for the Kamaji + Gaikai OAuth exchanges.
 	char duid[64];
 	size_t duid_size = sizeof(duid);
@@ -186,13 +199,21 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloud_provision_session(
 		return out->err;
 	}
 
+	// Poll between the pre-flight and the real flow (header contract: "polled
+	// between steps") so a cancel during the auth check stops before Kamaji runs.
+	if(cp_cancelled(cfg))
+	{
+		out->err = CHIAKI_ERR_CANCELED;
+		return out->err;
+	}
+
 	ChiakiErrorCode e = provision_once(log, cfg, duid, out);
 
 	// One-shot fallback: an owned fast-path entitlement that Gaikai rejects
 	// (noGameForEntitlementId) -> re-run the full Kamaji resolve/acquire once.
 	bool used_fast_path = cfg->owned_entitlement_id && *cfg->owned_entitlement_id;
 	if(e != CHIAKI_ERR_SUCCESS && used_fast_path && out->error_message &&
-	   strstr(out->error_message, "noGameForEntitlement"))
+	   strstr(out->error_message, "noGameForEntitlement") && !cp_cancelled(cfg))
 	{
 		CHIAKI_LOGW(log, "[CLOUDSESSION] owned entitlement rejected by Gaikai; retrying full resolve flow");
 		chiaki_cloud_provision_result_fini(out);

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -1149,13 +1149,21 @@ ChiakiErrorCode cc_gaikai_allocate(ChiakiLog *log,
 
 	c.spec = gk_build_spec(&c, entitlement_id ? entitlement_id : "");
 
+	// Poll cancellation between the early steps too (header contract); steps 10,
+	// 11, and 13 poll internally around their retry/wait loops.
 	bool psplus_err = false;
-	ChiakiErrorCode e = gk_step0_client_ids(&c);
+	ChiakiErrorCode e = gk_cancelled(&c) ? CHIAKI_ERR_CANCELED : gk_step0_client_ids(&c);
+	if(e == CHIAKI_ERR_SUCCESS && gk_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step7_config(&c);
+	if(e == CHIAKI_ERR_SUCCESS && gk_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step8_start(&c, out);
+	if(e == CHIAKI_ERR_SUCCESS && gk_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step8a_gk_authcode(&c);
+	if(e == CHIAKI_ERR_SUCCESS && gk_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step8b_server_authcode(&c);
+	if(e == CHIAKI_ERR_SUCCESS && gk_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step9_authorize(&c, out, &psplus_err);
+	if(e == CHIAKI_ERR_SUCCESS && gk_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step10_lock(&c);
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step11_datacenters(&c);
 	if(e == CHIAKI_ERR_SUCCESS) e = gk_step12_select(&c);

--- a/lib/src/cloudsession_gaikai.c
+++ b/lib/src/cloudsession_gaikai.c
@@ -616,7 +616,7 @@ static struct json_object *gk_ping_obj(const char *dc, int rtt_ms, uint32_t mtu_
 	int port, const char *ip, int max_bw, bool measured)
 {
 	struct json_object *o = json_object_new_object();
-	json_object_object_add(o, "dataCenter", json_object_new_string(dc));
+	json_object_object_add(o, "dataCenter", json_object_new_string(dc ? dc : "")); // dc is a strdup that may have failed (OOM), like ip below
 	json_object_object_add(o, "rtt", json_object_new_int(rtt_ms));
 	struct json_object *rtts = json_object_new_array();
 	json_object_array_add(rtts, json_object_new_int(rtt_ms));

--- a/lib/src/cloudsession_kamaji.c
+++ b/lib/src/cloudsession_kamaji.c
@@ -52,6 +52,8 @@ static bool km_cancelled(const KamajiCtx *c)
 	return c->cfg->is_cancelled && c->cfg->is_cancelled(c->cfg->user);
 }
 
+static void km_urlencode(const char *in, char *out, size_t out_size);
+
 static char *km_hdr(const char *key, const char *value)
 {
 	size_t n = strlen(key) + 2 + (value ? strlen(value) : 0) + 1;
@@ -260,9 +262,14 @@ static ChiakiErrorCode km_step0_5d_resolve(KamajiCtx *c, char **out_error)
 	if(c->cfg->progress) c->cfg->progress("Resolving Game - Step 2 of 5", c->cfg->user);
 	const char *country = (c->cfg->store_country && *c->cfg->store_country) ? c->cfg->store_country : "US";
 	const char *lang = (c->cfg->store_lang && *c->cfg->store_lang) ? c->cfg->store_lang : "en";
+	// Percent-encode the id before splicing it into the path: a no-op for real
+	// product ids ([A-Z0-9-_]), but a corrupted catalog entry containing ?/#//
+	// must not be able to rewrite the request.
+	char enc_pid[256];
+	km_urlencode(c->cfg->game_identifier, enc_pid, sizeof(enc_pid));
 	char url[512];
 	snprintf(url, sizeof(url), "https://psnow.playstation.com/store/api/pcnow/00_09_000/container/"
-		"%s/%s/19/%s?useOffers=true&gkb=1&gkb2=1", country, lang, c->cfg->game_identifier);
+		"%s/%s/19/%s?useOffers=true&gkb=1&gkb2=1", country, lang, enc_pid);
 	CHIAKI_LOGI(c->log, "[KAMAJI] 0.5d resolve %s (store %s/%s)", c->cfg->game_identifier, country, lang);
 
 	const char *hdrs[] = { "Accept: application/json",
@@ -499,7 +506,17 @@ static ChiakiErrorCode km_checkout_acquire(KamajiCtx *c, char **out_error)
 	}
 	struct json_object *pdata = cc_json_obj(pj, "data");
 	struct json_object *cart = pdata ? cc_json_obj(pdata, "cart") : NULL;
-	int total = cart ? cc_json_int(cart, "total_price_value") : -1;
+	if(!cart)
+	{
+		// A 200 without a parseable cart (maintenance page, schema drift) says
+		// nothing about the price -- fail generically instead of telling the user
+		// their free PS+ title "is not free".
+		CHIAKI_LOGE(c->log, "[KAMAJI] checkout preview returned 200 without a cart");
+		if(pj) json_object_put(pj);
+		free(h_auth); free(h_ua); free(h_cookie); cc_http_response_fini(&presp);
+		return CHIAKI_ERR_UNKNOWN;
+	}
+	int total = cc_json_int(cart, "total_price_value");
 	if(total != 0)
 	{
 		const char *price = cart ? cc_json_str(cart, "total_price") : "";
@@ -564,9 +581,11 @@ static ChiakiErrorCode km_step0_5e_check_acquire(KamajiCtx *c, char **out_error)
 	e = km_check_account_attributes(c, out_error);
 	if(e != CHIAKI_ERR_SUCCESS) return e;
 
-	char url[256];
+	char enc_ent[256];
+	km_urlencode(c->entitlement_id, enc_ent, sizeof(enc_ent)); // no-op for real ids, see 0.5d
+	char url[512];
 	snprintf(url, sizeof(url), "https://commerce.api.np.km.playstation.net/commerce/api/v1/users/me/"
-		"internal_entitlements/%s?fields=game_meta", c->entitlement_id);
+		"internal_entitlements/%s?fields=game_meta", enc_ent);
 	char *h_auth = NULL; cc_http_make_bearer_header(&h_auth, c->commerce_token);
 	char *h_ua = km_hdr("User-Agent", KM_USER_AGENT);
 	if(!h_auth || !h_ua) { free(h_auth); free(h_ua); return CHIAKI_ERR_MEMORY; } // OOM guard (else NULL header)

--- a/lib/src/cloudsession_kamaji.c
+++ b/lib/src/cloudsession_kamaji.c
@@ -47,6 +47,11 @@ typedef struct
 	char *commerce_token;
 } KamajiCtx;
 
+static bool km_cancelled(const KamajiCtx *c)
+{
+	return c->cfg->is_cancelled && c->cfg->is_cancelled(c->cfg->user);
+}
+
 static char *km_hdr(const char *key, const char *value)
 {
 	size_t n = strlen(key) + 2 + (value ? strlen(value) : 0) + 1;
@@ -455,6 +460,9 @@ static ChiakiErrorCode km_check_account_attributes(KamajiCtx *c, char **out_erro
 
 static ChiakiErrorCode km_checkout_acquire(KamajiCtx *c, char **out_error)
 {
+	// Last poll before the flow starts mutating the account: past this point a
+	// cancel can no longer prevent the $0 acquisition landing on the user's library.
+	if(km_cancelled(c)) return CHIAKI_ERR_CANCELED;
 	if(c->cfg->progress) c->cfg->progress("Acquiring License - Step 3 of 5", c->cfg->user);
 	char *h_auth = NULL; cc_http_make_bearer_header(&h_auth, c->commerce_token);
 	char *h_ua = km_hdr("User-Agent", KM_USER_AGENT);
@@ -521,6 +529,9 @@ static ChiakiErrorCode km_checkout_acquire(KamajiCtx *c, char **out_error)
 	cc_http_response_fini(&presp);
 
 	// --- buynow: complete the $0 acquire ---
+	// The preview above is read-only, so a cancel that landed during it can still
+	// stop cleanly here; buynow is the first request with a lasting side effect.
+	if(km_cancelled(c)) { free(h_auth); free(h_ua); free(h_cookie); return CHIAKI_ERR_CANCELED; }
 	char buy_body[256];
 	snprintf(buy_body, sizeof(buy_body), "sku=%s&skipEmail=true", c->streaming_sku);
 	const char *buy_hdrs[] = {
@@ -642,18 +653,26 @@ ChiakiErrorCode cc_kamaji_resolve(ChiakiLog *log,
 	}
 	else
 	{
+		// Poll cancellation between steps (header contract) so a user backing out
+		// mid-flow stops before the next network round-trip — most importantly
+		// before 0.5e, which can mutate the account (the $0 checkout).
 		char *anon_code = NULL;
 		e = km_step0_5b_anon_authcode(&c, &anon_code);
+		if(e == CHIAKI_ERR_SUCCESS && km_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 		if(e == CHIAKI_ERR_SUCCESS) e = km_step0_5c_anon_session(&c, anon_code);
 		free(anon_code);
+		if(e == CHIAKI_ERR_SUCCESS && km_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 		if(e == CHIAKI_ERR_SUCCESS) e = km_step0_5d_resolve(&c, out_error);
+		if(e == CHIAKI_ERR_SUCCESS && km_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 		if(e == CHIAKI_ERR_SUCCESS) e = km_step0_5e_check_acquire(&c, out_error);
 	}
 
+	if(e == CHIAKI_ERR_SUCCESS && km_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 	if(e == CHIAKI_ERR_SUCCESS)
 	{
 		char *auth_code = NULL;
 		e = km_step5_authcode(&c, &auth_code);
+		if(e == CHIAKI_ERR_SUCCESS && km_cancelled(&c)) e = CHIAKI_ERR_CANCELED;
 		if(e == CHIAKI_ERR_SUCCESS) e = km_step6_auth_session(&c, auth_code);
 		free(auth_code);
 	}

--- a/lib/src/common.c
+++ b/lib/src/common.c
@@ -6,6 +6,8 @@
 
 #include <galois.h>
 
+#include <curl/curl.h>
+
 #include <errno.h>
 #include <stdlib.h>
 #include <time.h>
@@ -102,6 +104,13 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_lib_init()
 			return CHIAKI_ERR_NETWORK;
 	}
 #endif
+
+	// libcurl's lazy global init on the first curl_easy_init is not thread-safe
+	// (documented for libcurl < 7.84): do it once here, before any catalog or
+	// provisioning worker can race it. Refcounted, so a platform that also calls
+	// curl_global_init itself stays correct.
+	if(curl_global_init(CURL_GLOBAL_DEFAULT) != 0)
+		return CHIAKI_ERR_UNKNOWN;
 
 	return CHIAKI_ERR_SUCCESS;
 }

--- a/lib/src/curl_http.c
+++ b/lib/src/curl_http.c
@@ -46,6 +46,9 @@ static void redact_credentials(char *buf, size_t len)
 {
 	static const char *const keys[] = {
 		"npsso", "jsessionid", "bearer", "access_token", "refresh_token", "id_token", "code",
+		// Gaikai stream secrets: the allocate response's handshake key / launch spec
+		// and the live session header are enough to hijack the stream they protect.
+		"handshakekey", "launchspecification", "x-gaikai-session",
 	};
 	for(size_t k = 0; k < sizeof(keys) / sizeof(keys[0]); k++)
 	{

--- a/test/cloudsession_kamaji.c
+++ b/test/cloudsession_kamaji.c
@@ -82,9 +82,35 @@ static MunitResult test_gd_fallback_none(const MunitParameter p[], void *data)
 	return MUNIT_OK;
 }
 
+static bool always_cancelled(void *user)
+{
+	(void)user;
+	return true;
+}
+
+// A cancel that lands before provisioning starts must return CHIAKI_ERR_CANCELED
+// without any network activity (the entry poll runs before the DUID/auth pre-flight,
+// so this test is fully offline).
+static MunitResult test_cancelled_before_start(const MunitParameter p[], void *data)
+{
+	(void)p; (void)data;
+	ChiakiCloudProvisionConfig cfg;
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.npsso = "test-npsso";
+	cfg.service_type = "psnow";
+	cfg.game_identifier = "UP9000-CUSA12345_00-FULLGAME00000001";
+	cfg.is_cancelled = always_cancelled;
+	ChiakiCloudProvisionResult out;
+	munit_assert_int(chiaki_cloud_provision_session(&cfg, &out, NULL), ==, CHIAKI_ERR_CANCELED);
+	munit_assert_int(out.err, ==, CHIAKI_ERR_CANCELED);
+	chiaki_cloud_provision_result_fini(&out);
+	return MUNIT_OK;
+}
+
 MunitTest tests_cloudsession_kamaji[] = {
 	{ "/gd_fallback_picks_gd", test_gd_fallback_picks_gd, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/gd_fallback_title_match", test_gd_fallback_title_match, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/gd_fallback_none", test_gd_fallback_none, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/cancelled_before_start", test_cancelled_before_start, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };


### PR DESCRIPTION
Fixes from the round-3 review of #25 — 6 majors plus the safe subset of minors, one commit each. Every change is either a guard on a path that is currently broken (cancel, error, shutdown races) or a copy of a pattern already live-verified elsewhere in 2.11.

## Majors
- **lib**: cancellation now polled between every provisioning step — a cancel can no longer trigger the account-mutating $0 buynow checkout or ride out ~6 more HTTP round-trips (offline unit test added; 118/118 green)
- **lib**: a transient owned-entitlements failure no longer caches an ownership-less catalog for 24h (`owned_complete` joins the existing `apollo_complete`/`browse_complete` guard)
- **lib**: verbose-log redaction extended to the Gaikai stream secrets (`handshakeKey`, `launchSpecification`, `X-Gaikai-Session`)
- **ios**: sync PSN path gets the same `isShutDown` publish guard as the async path (b0883d10 covered only one of two creation paths); holepunch claim consumed on the worker thread with `@synchronized` accessors, killing the shutdown double-fini; join task and start-failure paths now clear `sessionRef` on main **before** freeing, closing the freed-session window the 1 Hz stats poll and controller callbacks could hit
- **android**: provisioning coroutine survives fragment destruction (rethrow `CancellationException`, `activity?`-guard the failure paths — was a guaranteed crash ~5–30 s after backing out mid-allocation)

## Minors (all covered by the same happy-path testing)
- 5xx at OAuth/session steps → transient error, not a false "session expired, log in again" banner
- `extract_param` no longer matches `code=` inside `error_code=`
- fallback pagination: missing `total_results` / early-dry page → incomplete (not cacheable), hard page cap
- checkout preview 200-without-cart → generic failure, not "game not free"
- cache temp files unique per write + `fclose` checked (atomic-replace promise now holds)
- `curl_global_init` once at `chiaki_lib_init` (pre-7.84 first-use race)
- kamaji ids percent-encoded into URL paths (no-op for real ids)
- Android owned fast-path gated like Qt (`isOwned && psnow && entitlementId`)
- Qt: `qApp` null-guard on worker completion (exit-time crash); stats overlay Mbps/packet-loss labels guard the session like their siblings
- iOS: ping-job `dc` OOM guard; `CachedAsyncImage` stale-load guard

## Verification
- lib unit suite: **118/118** (includes new `cancelled_before_start`)
- macOS: built via `build-macos.sh --iterate`, launched, catalog cache loads (`[CACHE HIT] unified_catalog_v3`), zero log errors
- iOS: full build (`PYLUX_FULL_BUILD=1 ios/build.sh iterate`) green
- Android: `build-local.sh --quick` green
- Deferred by design (need dedicated retest): `settledLocale` convergence, Qt worker-thread joining

🤖 Generated with [Claude Code](https://claude.com/claude-code)