### PR TITLE
Cloud play fixes for HU region (and possibly other non-US regions)

### DIFF
--- a/.github/workflows/build-artifact-android.yml
+++ b/.github/workflows/build-artifact-android.yml
@@ -1,0 +1,73 @@
+# Build Android artifact — on-demand, build-only.
+
+name: Build Android (artifact)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-artifact-android-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Android (artifact)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set short commit hash
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Extract version
+        id: extract_version
+        uses: ./.github/actions/extract-version
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install NDK and CMake
+        run: |
+          sdkmanager --install \
+            "ndk;28.2.13676358" \
+            "cmake;3.30.4" \
+            "build-tools;35.0.0" \
+            "platforms;android-35"
+
+      - name: Install protobuf tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq protobuf-compiler
+          pip3 install 'protobuf>=5,<6' 'grpcio-tools>=1.60'
+
+      # No keystore/signing: assembleDebug uses the auto-generated debug key.
+      # We only need sdk.dir; the chiakiKeystore block in app/build.gradle stays
+      # disabled, so the build is debug-signed (no release keystore secret needed).
+      - name: Write local.properties
+        working-directory: android
+        run: echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+
+      - name: Build debug APK
+        working-directory: android
+        run: |
+          ./gradlew assembleDebug \
+            --parallel \
+            --build-cache \
+            -Dorg.gradle.java.home="$JAVA_HOME"
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pylux-Android-${{ steps.extract_version.outputs.version }}-${{ env.SHORT_SHA }}.apk
+          path: android/app/build/outputs/apk/debug/*.apk
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/build-artifact-ios.yml
+++ b/.github/workflows/build-artifact-ios.yml
@@ -1,0 +1,123 @@
+# Build iOS artifact — on-demand, build-only.
+# The .ipa is NOT installable directly — a sideloading
+# tool (AltStore/Sideloadly) must re-sign it with the user's own Apple ID first.
+
+name: Build iOS (artifact)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-artifact-ios-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build iOS unsigned .ipa (artifact)
+    runs-on: macos-26
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set short commit hash
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Extract version
+        id: extract_version
+        uses: ./.github/actions/extract-version
+
+      - name: Install build dependencies
+        run: |
+          retry() {
+            local attempts="$1"
+            shift
+            local n=1
+            until "$@"; do
+              if [ "$n" -ge "$attempts" ]; then
+                echo "Command failed after $n attempts: $*"
+                return 1
+              fi
+              local sleep_s=$((n * 15))
+              echo "Attempt $n failed; retrying in ${sleep_s}s: $*"
+              sleep "$sleep_s"
+              n=$((n + 1))
+            done
+          }
+          retry 4 brew install cmake ninja protobuf@29 python-setuptools
+          pip3 install --user --break-system-packages 'protobuf>=5,<6'
+          echo "$(brew --prefix)/opt/protobuf@29/bin" >> "$GITHUB_PATH"
+
+      - name: Download iOS toolchain
+        working-directory: ios
+        run: |
+          if [ ! -f ios.toolchain.cmake ]; then
+            curl -sL -o ios.toolchain.cmake \
+              https://raw.githubusercontent.com/leetal/ios-cmake/master/ios.toolchain.cmake
+          fi
+
+      - name: Build chiaki-lib (device)
+        working-directory: ios
+        run: |
+          cmake -S . -B build-iphoneos -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE=ios.toolchain.cmake \
+            -DPLATFORM=OS64 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_LIBIDN2=OFF \
+            -DCURL_USE_LIBPSL=OFF \
+            -DUSE_NGHTTP2=OFF \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake --build build-iphoneos --config Release --target chiaki-lib
+
+      - name: Create combined static library
+        working-directory: ios
+        run: |
+          find build-iphoneos -name "*.a" -print0 | \
+            xargs -0 libtool -static -o build-iphoneos/libchiaki_complete.a
+
+      - name: Set iOS marketing + build numbers from CMake (root CMakeLists.txt)
+        run: |
+          echo "IOS_MARKETING_VERSION=${{ steps.extract_version.outputs.version }}" >> "$GITHUB_ENV"
+          echo "IOS_CURRENT_PROJECT_VERSION=${{ steps.extract_version.outputs.semver_build_id }}" >> "$GITHUB_ENV"
+
+      # Archive with code signing fully disabled — no cert/profile/secrets needed.
+      - name: Archive (unsigned)
+        working-directory: ios
+        run: |
+          xcodebuild -project Pylux.xcodeproj \
+            -scheme Pylux \
+            -sdk iphoneos \
+            -configuration Release \
+            archive \
+            -destination 'generic/platform=iOS' \
+            -archivePath build-derived/Pylux.xcarchive \
+            -derivedDataPath build-derived \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="${IOS_MARKETING_VERSION}" \
+            CURRENT_PROJECT_VERSION="${IOS_CURRENT_PROJECT_VERSION}"
+
+      # Hand-roll an UNSIGNED .ipa: zip the .app into Payload/ (sideload-only).
+      - name: Package unsigned .ipa
+        working-directory: ios
+        run: |
+          APP=$(find build-derived/Pylux.xcarchive/Products/Applications \
+            -maxdepth 1 -name "*.app" | head -1)
+          if [ -z "$APP" ] || [ ! -d "$APP" ]; then
+            echo "::error::No .app found in archive — cannot build .ipa"
+            exit 1
+          fi
+          rm -rf payload-staging && mkdir -p payload-staging/Payload
+          cp -R "$APP" payload-staging/Payload/
+          ( cd payload-staging && zip -ry "../Pylux-unsigned.ipa" Payload )
+          echo "Built unsigned IPA: ios/Pylux-unsigned.ipa (sideload with AltStore/Sideloadly)"
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pylux-iOS-${{ steps.extract_version.outputs.version }}-${{ env.SHORT_SHA }}.ipa
+          path: ios/Pylux-unsigned.ipa
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/build-artifact-linux.yml
+++ b/.github/workflows/build-artifact-linux.yml
@@ -1,0 +1,68 @@
+# Build Linux artifact — on-demand, build-only.
+
+name: Build Linux (artifact)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-artifact-linux-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Linux x86_64 (artifact)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install tools
+        run: sudo apt-get update && sudo apt-get -y install podman zip jq
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: pylux
+
+      - name: Set short commit hash
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Add QmlWebEngine import
+        working-directory: pylux
+        run: cp scripts/qtwebengine_import.qml gui/src/qml/
+
+      - name: Build in container
+        working-directory: pylux
+        run: |
+          podman run --rm \
+            -v "$PWD:/build/chiaki" \
+            -w "/build/chiaki" \
+            --device /dev/fuse \
+            --cap-add SYS_ADMIN \
+            -t docker.io/streetpea/chiaki-ng-builder:qt6.9 \
+            /bin/bash -c "sudo -E scripts/build-appimage.sh /build/appdir"
+
+      - name: Package portable zip
+        working-directory: pylux/appimage
+        run: zip -r pylux.zip pylux
+
+      - name: Extract version
+        id: extract_version
+        uses: ./pylux/.github/actions/extract-version
+        with:
+          cmakelists: pylux/CMakeLists.txt
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pylux-Linux-${{ steps.extract_version.outputs.version }}-${{ env.SHORT_SHA }}.AppImage
+          path: pylux/appimage/pylux.AppImage
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload portable zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pylux-Linux-${{ steps.extract_version.outputs.version }}-${{ env.SHORT_SHA }}.zip
+          path: pylux/appimage/pylux.zip
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/build-artifact-macos.yml
+++ b/.github/workflows/build-artifact-macos.yml
@@ -1,0 +1,45 @@
+# Build macOS artifact — on-demand, build-only.
+
+name: Build macOS (artifact)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-artifact-macos-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build macOS arm64 (artifact)
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set short commit hash
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Extract version
+        id: extract_version
+        uses: ./.github/actions/extract-version
+
+      # Ad-hoc, no credentials file, no notarization, no notary keychain.
+      # build-macos.sh installs its own Homebrew deps and skips the DMG when
+      # notarization is off; we package the .app it leaves in build-output/.
+      - name: Build ad-hoc .app
+        run: bash scripts/build-macos.sh arm64 --ad-hoc --no-credentials-file --no-notarize --skip-notary-keychain
+
+      - name: Zip .app bundle
+        working-directory: build-output
+        run: zip -ry Pylux-macos.zip Pylux.app
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pylux-macOS-${{ steps.extract_version.outputs.version }}-${{ env.SHORT_SHA }}.zip
+          path: build-output/Pylux-macos.zip
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/build-artifact-windows.yml
+++ b/.github/workflows/build-artifact-windows.yml
@@ -1,0 +1,200 @@
+# Build Windows artifact — on-demand, build-only.
+
+name: Build Windows (artifact)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-artifact-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHIAKI_ENABLE_STEAMWORKS: "OFF"
+
+jobs:
+  build:
+    name: Build Windows x86_64 (artifact)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Disable autocrlf
+        shell: pwsh
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: true
+          install: git
+          pacboy: >-
+            ca-certificates:p
+            cc:p
+            cmake:p
+            curl:p
+            diffutils:p
+            fast_float:p
+            fftw:p
+            hidapi:p
+            json-c:p
+            lcms2:p
+            libdovi:p
+            meson:p
+            miniupnpc:p
+            gcc:p
+            nasm:p
+            ninja:p
+            openssl:p
+            opus:p
+            pkgconf:p
+            protobuf:p
+            python:p
+            python-psutil:p
+            python-glad:p
+            python-jinja:p
+            python-pip:p
+            qt6-base:p
+            qt6-declarative:p
+            qt6-svg:p
+            SDL2:p
+            shaderc:p
+            speexdsp:p
+            spirv-cross:p
+            vulkan:p
+            vulkan-headers:p
+
+      - name: Set short commit hash
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Install python protobuf and zip
+        run: |
+          pip install protobuf
+          pacman -S git make unzip zip jq --noconfirm
+
+      - name: Build libbplacebo
+        run: |
+          scripts/build-libplacebo-windows.sh
+
+      - name: Setup ffmpeg
+        run: |
+          curl -LO https://github.com/streetpea/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip
+          unzip ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip
+          cp -a "ffmpeg-n7.1-latest-win64-gpl-shared-7.1/bin/." /mingw64/bin
+          cp -a "ffmpeg-n7.1-latest-win64-gpl-shared-7.1/include/." /mingw64/include
+          cp -a "ffmpeg-n7.1-latest-win64-gpl-shared-7.1/lib/." /mingw64/lib
+
+      - name: Add QmlWebEngine Import
+        run: |
+          cp scripts/qtwebengine_import.qml gui/src/qml/
+
+      - name: Configure Pylux
+        run: |
+          cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCHIAKI_ENABLE_CLI=OFF -DCHIAKI_ENABLE_STEAMWORKS=${{ env.CHIAKI_ENABLE_STEAMWORKS }} -DCHIAKI_ENABLE_STEAM_SHORTCUT=ON
+
+      - name: Build Pylux
+        run: |
+          cmake --build build --config Release --clean-first --target chiaki
+
+      - name: Package Pylux
+        run: |
+          mkdir pylux
+          cp build/gui/chiaki.exe pylux/pylux.exe
+          if [ "${{ env.CHIAKI_ENABLE_STEAMWORKS }}" = "ON" ]; then
+            cp third-party/steamworks/steamworks_sdk/redistributable_bin/win64/steam_api64.dll pylux/
+            cp steam_appid.txt pylux/ 2>/dev/null || echo "Warning: steam_appid.txt not found"
+          fi
+          export PATH="${{ github.workspace }}/build/third-party/cpp-steam-tools:/mingw64/share/qt6/bin/:/mingw64/bin/:${PATH}"
+          export QT_PLUGIN_PATH="/mingw64/share/qt6/plugins"
+          export QML2_IMPORT_PATH="/mingw64/share/qt6/qml"
+          # Recursively find and copy DLL dependencies of pylux.exe
+          echo pylux/pylux.exe > tmp0.txt
+          while [ -e tmp0.txt ]
+          do
+            cp tmp0.txt tmp.txt
+            rm tmp0.txt
+            sort -u tmp.txt -o tmp.txt
+            ldd $(<tmp.txt) | awk '($2 == "=>") { print $3 }' | while read -r dep; do
+              case "$dep" in
+                ""|*"/Windows/"*|*"/WINDOWS/"*|*"/System32/"*|*"/SYSTEM32/"*|*"/SysWOW64/"*|*"/SYSWOW64/"*)
+                  continue
+                  ;;
+              esac
+              if [ -f "$dep" ] && [ ! -e "pylux/${dep##*/}" ]; then
+                echo "Copied $dep"
+                cp "$dep" pylux/
+                echo "$dep" >> tmp0.txt
+              fi
+            done
+          done
+          # Copy Qt plugins and QML modules
+          windeployqt6.exe --no-translations --qmldir=gui/src/qml pylux/pylux.exe
+          # Copy dependencies of Qt plugins (windeployqt6 doesn't copy plugin dependencies like libjpeg-8.dll)
+          echo "Finding Qt plugin DLLs..."
+          find pylux -type d \( -name plugins -o -name imageformats -o -name platforms -o -name sqldrivers \) -exec find {} -name "*.dll" \; | while read plugin; do
+            echo "Found plugin: $plugin"
+            echo "$plugin" >> tmp0.txt
+          done
+          echo "Copying plugin dependencies..."
+          while [ -e tmp0.txt ] && [ -s tmp0.txt ]
+          do
+            cp tmp0.txt tmp.txt
+            rm tmp0.txt
+            sort -u tmp.txt -o tmp.txt
+            ldd $(<tmp.txt) 2>/dev/null | awk '($2 == "=>") { print $3 }' | while read -r dep; do
+              case "$dep" in
+                ""|*"/Windows/"*|*"/WINDOWS/"*|*"/System32/"*|*"/SYSTEM32/"*|*"/SysWOW64/"*|*"/SYSWOW64/"*)
+                  continue
+                  ;;
+              esac
+              if [ -f "$dep" ] && [ ! -e "pylux/${dep##*/}" ]; then
+                echo "  Copying plugin dependency: ${dep##*/}"
+                cp "$dep" pylux/
+                echo "$dep" >> tmp0.txt
+              fi
+            done
+          done
+          rm -f tmp0.txt tmp.txt
+
+      - name: Create portable zip
+        run: |
+          zip -r pylux.zip pylux
+
+      - name: Extract version
+        id: extract_version
+        uses: ./.github/actions/extract-version
+
+      - name: Compile .ISS to .EXE Installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
+        with:
+          path: "scripts/chiaki-ng.iss"
+          options: /O+
+
+      - name: Rename installer with version
+        run: |
+          INSTALLER_NAME="pylux-windows-installer-${{ steps.extract_version.outputs.version }}.exe"
+          cp pylux-windows-installer.exe "${INSTALLER_NAME}"
+          echo "INSTALLER_NAME=${INSTALLER_NAME}" >> $GITHUB_ENV
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pylux-Windows-${{ steps.extract_version.outputs.version }}-${{ env.SHORT_SHA }}.exe
+          path: ${{ env.INSTALLER_NAME }}
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload portable zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pylux-Windows-${{ steps.extract_version.outputs.version }}-${{ env.SHORT_SHA }}.zip
+          path: pylux.zip
+          retention-days: 14
+          if-no-files-found: error

--- a/lib/include/chiaki/cloudcatalog.h
+++ b/lib/include/chiaki/cloudcatalog.h
@@ -35,8 +35,9 @@ extern "C" {
  * v5: public Classics fallback uses the dedicated regional PS3 child container;
  *     invalidates v4 caches that could contain no PS3 titles after walking APOLLOROOT.
  * v6: owned rows always expose their canonical entitlementId and storeProductId,
- *     including when the entitlement id equals productId. */
-#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 6
+ *     including when the entitlement id equals productId.
+ * v7: explicit disc-upgrade rescues launch through their replacement product id. */
+#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 7
 
 typedef struct chiaki_cloudcatalog_config_t
 {
@@ -63,7 +64,7 @@ typedef struct chiaki_cloudcatalog_result_t
  * The JSON envelope (see CHIAKI_CLOUDCATALOG_SCHEMA_VERSION):
  *
  *   {
- *     "schemaVersion": 6,
+ *     "schemaVersion": 7,
  *     "total": <int>,
  *     "nativeMode": <bool>,            // true when the authenticated PS Now walk succeeded
  *     "fallbackRegion": "US"|"HU"|...,  // account country used for modern product resolution;

--- a/lib/include/chiaki/cloudcatalog.h
+++ b/lib/include/chiaki/cloudcatalog.h
@@ -31,8 +31,10 @@ extern "C" {
  *     than after the 24h TTL.
  * v4: guarantees that productId is unique in the games array. Older unified caches
  *     could contain the same owned PS5 edition through both psnow and pscloud routes,
- *     which also violated Android RecyclerView's former stable-ID assumption. */
-#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 4
+ *     which also violated Android RecyclerView's former stable-ID assumption.
+ * v5: public Classics fallback uses the dedicated regional PS3 child container;
+ *     invalidates v4 caches that could contain no PS3 titles after walking APOLLOROOT. */
+#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 5
 
 typedef struct chiaki_cloudcatalog_config_t
 {

--- a/lib/include/chiaki/cloudcatalog.h
+++ b/lib/include/chiaki/cloudcatalog.h
@@ -33,8 +33,10 @@ extern "C" {
  *     could contain the same owned PS5 edition through both psnow and pscloud routes,
  *     which also violated Android RecyclerView's former stable-ID assumption.
  * v5: public Classics fallback uses the dedicated regional PS3 child container;
- *     invalidates v4 caches that could contain no PS3 titles after walking APOLLOROOT. */
-#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 5
+ *     invalidates v4 caches that could contain no PS3 titles after walking APOLLOROOT.
+ * v6: owned rows always expose their canonical entitlementId and storeProductId,
+ *     including when the entitlement id equals productId. */
+#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 6
 
 typedef struct chiaki_cloudcatalog_config_t
 {
@@ -61,10 +63,11 @@ typedef struct chiaki_cloudcatalog_result_t
  * The JSON envelope (see CHIAKI_CLOUDCATALOG_SCHEMA_VERSION):
  *
  *   {
- *     "schemaVersion": 4,
+ *     "schemaVersion": 6,
  *     "total": <int>,
  *     "nativeMode": <bool>,            // true when the authenticated PS Now walk succeeded
- *     "fallbackRegion": "US"|"GB"|...,  // server-authoritative store country for container URLs
+ *     "fallbackRegion": "US"|"HU"|...,  // account country used for modern product resolution;
+ *                                      // legacy PS3 ids map to the regional US/GB Classics store
  *     "resolvedStoreLang": "nl"|"",    // server store language parsed from the native base_url;
  *                                      // clients use it for the step0_5d container URL (a non-English
  *                                      // native store 404s on the wrong language). "" in fallback mode.

--- a/lib/include/chiaki/cloudcatalog.h
+++ b/lib/include/chiaki/cloudcatalog.h
@@ -28,8 +28,11 @@ extern "C" {
  *     and must be refetched.
  * v3: adds "resolvedStoreLang" (server store language for the step0_5d container URL);
  *     bumped so existing caches refetch and clients get the field immediately rather
- *     than after the 24h TTL. */
-#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 3
+ *     than after the 24h TTL.
+ * v4: guarantees that productId is unique in the games array. Older unified caches
+ *     could contain the same owned PS5 edition through both psnow and pscloud routes,
+ *     which also violated Android RecyclerView's former stable-ID assumption. */
+#define CHIAKI_CLOUDCATALOG_SCHEMA_VERSION 4
 
 typedef struct chiaki_cloudcatalog_config_t
 {
@@ -56,7 +59,7 @@ typedef struct chiaki_cloudcatalog_result_t
  * The JSON envelope (see CHIAKI_CLOUDCATALOG_SCHEMA_VERSION):
  *
  *   {
- *     "schemaVersion": 3,
+ *     "schemaVersion": 4,
  *     "total": <int>,
  *     "nativeMode": <bool>,            // true when the authenticated PS Now walk succeeded
  *     "fallbackRegion": "US"|"GB"|...,  // server-authoritative store country for container URLs
@@ -68,7 +71,7 @@ typedef struct chiaki_cloudcatalog_result_t
  *                                      // locale chain settles); clients persist this verbatim
  *     "warning": "",                   // non-empty => client shows a banner verbatim (e.g. expired npsso)
  *     "games": [ {
- *       "productId":        <string>,  // canonical catalog id + stable dedup key
+ *       "productId":        <string>,  // canonical catalog id; unique in this array
  *       "name":             <string>,
  *       "imageUrl":         <string>,  // portrait/box art
  *       "landscapeImageUrl":<string>,

--- a/lib/src/cloudcatalog_consts.c
+++ b/lib/src/cloudcatalog_consts.c
@@ -36,11 +36,11 @@ const char *cc_classics_store_country(const char *account_country)
 	return is_americas_classics_region(account_country) ? "US" : "GB";
 }
 
-const char *cc_apollo_root_container_id(const char *account_country)
+const char *cc_classics_ps3_container_id(const char *account_country)
 {
 	return is_americas_classics_region(account_country)
-		? "STORE-MSF192018-APOLLOROOT"
-		: "STORE-MSF192014-APOLLOROOT";
+		? "STORE-MSF192018-APOLLOPS3GAMES"
+		: "STORE-MSF192014-APOLLOPS3";
 }
 
 // Canonicalize "language-COUNTRY" to lowercase-lang / uppercase-country.

--- a/lib/src/cloudcatalog_fetch.c
+++ b/lib/src/cloudcatalog_fetch.c
@@ -3,7 +3,7 @@
 // Blocking network fetch flows for the unified cloud catalog. Faithful port of
 // the async QNetworkAccessManager state machines in cloudcatalogbackend.cpp:
 //   - PS Now OAuth -> session -> stores -> APOLLOROOT root + alphabetical walk
-//   - public APOLLOROOT fallback pagination (region-unsupported accounts)
+//   - public PS3 Classics child-container pagination (region-unsupported accounts)
 //   - imagic 6-list fetch with locale fallback chain
 //   - owned entitlements OAuth(token) -> paginated internal_entitlements -> filter
 
@@ -504,7 +504,7 @@ CCNativeResult cc_fetch_psnow_native(ChiakiLog *log, const char *npsso, struct j
 }
 
 // ===========================================================================
-// Public APOLLOROOT fallback pagination
+// Public PS3 Classics fallback pagination
 // ===========================================================================
 
 struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account_country, bool *out_complete)
@@ -512,7 +512,7 @@ struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account
 	if(out_complete)
 		*out_complete = true;
 	const char *store_country = cc_classics_store_country(account_country);
-	const char *container = cc_apollo_root_container_id(account_country);
+	const char *container = cc_classics_ps3_container_id(account_country);
 	char container_url[512];
 	snprintf(container_url, sizeof(container_url),
 		"https://psnow.playstation.com/store/api/pcnow/00_09_000/container/%s/en/19/%s",
@@ -538,7 +538,7 @@ struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account
 			// incomplete so the caller never caches a partial classics list.
 			if(out_complete)
 				*out_complete = false;
-			CHIAKI_LOGW(log, "[UNIFIED] APOLLOROOT fallback page at start=%d failed; list incomplete", start);
+			CHIAKI_LOGW(log, "[UNIFIED] PS3 Classics fallback page at start=%d failed; list incomplete", start);
 			break;
 		}
 		struct json_object *obj = parse_body(&resp);
@@ -547,7 +547,7 @@ struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account
 		{
 			if(out_complete)
 				*out_complete = false;
-			CHIAKI_LOGW(log, "[UNIFIED] APOLLOROOT fallback page at start=%d unparseable; list incomplete", start);
+			CHIAKI_LOGW(log, "[UNIFIED] PS3 Classics fallback page at start=%d unparseable; list incomplete", start);
 			break;
 		}
 		if(total < 0 && cc_json_has(obj, "total_results"))
@@ -582,7 +582,7 @@ struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account
 			// completeness, so serve what we have but don't let it cache.
 			if(out_complete)
 				*out_complete = false;
-			CHIAKI_LOGW(log, "[UNIFIED] APOLLOROOT fallback ended at start=%d without a confirmed total; list incomplete", start - 100);
+			CHIAKI_LOGW(log, "[UNIFIED] PS3 Classics fallback ended at start=%d without a confirmed total; list incomplete", start - 100);
 			break;
 		}
 		if(start >= 10000)
@@ -591,11 +591,11 @@ struct json_object *cc_fetch_apollo_fallback(ChiakiLog *log, const char *account
 			// total) can't spin this loop forever.
 			if(out_complete)
 				*out_complete = false;
-			CHIAKI_LOGW(log, "[UNIFIED] APOLLOROOT fallback page cap hit at start=%d; list incomplete", start);
+			CHIAKI_LOGW(log, "[UNIFIED] PS3 Classics fallback page cap hit at start=%d; list incomplete", start);
 			break;
 		}
 	}
-	CHIAKI_LOGI(log, "[UNIFIED] APOLLOROOT fallback: %d titles", (int)json_object_array_length(games));
+	CHIAKI_LOGI(log, "[UNIFIED] PS3 Classics fallback: %d titles", (int)json_object_array_length(games));
 	return games;
 }
 

--- a/lib/src/cloudcatalog_internal.h
+++ b/lib/src/cloudcatalog_internal.h
@@ -87,8 +87,8 @@ struct json_object *cc_json_clone(struct json_object *src);
 /** "US" for Americas account regions, else "GB". @p account_country may be NULL. */
 const char *cc_classics_store_country(const char *account_country);
 
-/** Fully-qualified APOLLOROOT container id for the account's region group. */
-const char *cc_apollo_root_container_id(const char *account_country);
+/** Fully-qualified PS3 Classics child-container id for the account's region group. */
+const char *cc_classics_ps3_container_id(const char *account_country);
 
 /**
  * Build the ordered store-locale fallback chain (canonical, en-COUNTRY, en-US).
@@ -218,7 +218,7 @@ CCNativeResult cc_fetch_psnow_native(ChiakiLog *log, const char *npsso, struct j
 	bool *out_complete);
 
 /**
- * Public APOLLOROOT fallback pagination for @p account_country. New array or NULL.
+ * Public PS3 Classics child-container pagination for @p account_country. New array or NULL.
  * *out_complete (may be NULL) is set false when pagination aborted early on an
  * HTTP/parse error, so callers must not cache the partial list.
  */

--- a/lib/src/cloudcatalog_merge.c
+++ b/lib/src/cloudcatalog_merge.c
@@ -512,6 +512,8 @@ static struct json_object *merge_owned_into_browse(struct json_object *browse,
 			if(cc_ieq(owned_service, "pscloud"))
 			{
 				cc_json_set_bool(existing, "isOwned", true);
+				if(cc_json_bool(owned_game, "preferProductForStreaming"))
+					cc_json_set_bool(existing, "preferProductForStreaming", true);
 				const char *owned_id = cc_json_str(owned_game, "id");
 				if(*owned_id)
 					cc_json_set_str(existing, "id", owned_id);
@@ -691,7 +693,8 @@ static void streamability_fini(StreamabilityIndex *ix)
 
 // ---------------------------------------------------------------------------
 // streamIdentifier (contract field): what the streaming layer is handed.
-//   pscloud: the entitlement's own id when owned, else the catalog productId.
+//   pscloud: the entitlement id when owned, except an explicit disc-upgrade
+//            rescue whose stale wrapper is replaced with a launchable product id.
 //   psnow:   the catalog product variant (catalogProductId or productId).
 // ---------------------------------------------------------------------------
 
@@ -699,9 +702,22 @@ static const char *stream_identifier(struct json_object *g, const char *stream_s
 {
 	if(strcmp(stream_service, "pscloud") == 0)
 	{
-		const char *id = cc_json_str(g, "id");
-		if(cc_json_bool(g, "isOwned") && *id)
-			return id;
+		if(cc_json_bool(g, "isOwned"))
+		{
+			if(cc_json_bool(g, "preferProductForStreaming"))
+			{
+				const char *product = cc_json_str(g, "storeProductId");
+				if(!*product)
+					product = cc_json_str(g, "product_id");
+				if(!*product)
+					product = game_product_id(g);
+				if(*product)
+					return product;
+			}
+			const char *id = cc_json_str(g, "id");
+			if(*id)
+				return id;
+		}
 		return game_product_id(g);
 	}
 	const char *cat = cc_json_str(g, "catalogProductId");
@@ -1264,6 +1280,7 @@ struct json_object *cc_build_owned_cross_ref(ChiakiLog *log,
 		cc_json_set_str(entry, "product_id", replacement);
 		cc_json_set_str(entry, "productId", replacement);
 		cc_json_set_str(entry, "catalogProductId", replacement);
+		cc_json_set_bool(entry, "preferProductForStreaming", true);
 		CHIAKI_LOGI(log, "[CROSS-REF] disc-upgrade rescue: %s -> %s", disc_name, replacement);
 	}
 

--- a/lib/src/cloudcatalog_merge.c
+++ b/lib/src/cloudcatalog_merge.c
@@ -1400,10 +1400,25 @@ struct json_object *cc_assemble_unified_catalog(ChiakiLog *log, const CCAssemble
 		// normalize identity fields the clients read
 		if(!cc_json_has(g, "productId") && cc_json_has(g, "product_id"))
 			cc_json_set_str(g, "productId", cc_json_str(g, "product_id"));
+		// Owned rows must expose their entitlement even when it is the canonical
+		// full-game id and therefore equals productId. The PSNOW owned fast path
+		// consumes this field to skip a store product lookup; treating equality as
+		// "not an entitlement" regressed titles whose catalog alias no longer
+		// resolves (God of War 2018 is one such PAL-store title).
 		const char *ent = game_entitlement_id(g);
+		if(cc_json_bool(g, "isOwned"))
+		{
+			const char *owned_id = cc_json_str(g, "id");
+			if(*owned_id)
+				ent = owned_id;
+		}
 		if(*ent)
 			cc_json_set_str(g, "entitlementId", ent);
-		const char *store = cc_json_str(g, "catalogProductId");
+		// Likewise preserve the entitlement API's product_id for owned rows.
+		// catalogProductId is the browse alias and can be a different SKU.
+		const char *store = cc_json_bool(g, "isOwned") ? cc_json_str(g, "product_id") : "";
+		if(!*store)
+			store = cc_json_str(g, "catalogProductId");
 		if(!*store)
 			store = cc_json_str(g, "storeProductId");
 		if(*store)

--- a/lib/src/cloudcatalog_merge.c
+++ b/lib/src/cloudcatalog_merge.c
@@ -382,6 +382,66 @@ static int sort_owned_then_name(const void *a, const void *b)
 	return strcasecmp(game_name(ao), game_name(bo));
 }
 
+// Exact productId duplicates can be created after ownership stamping: two source
+// rows that started with different catalog ids may both be rewritten to the owned
+// product id. Keep the route the UI can actually use now (owned pscloud first,
+// otherwise subscription-streamable psnow) and preserve list membership metadata.
+static int contract_game_rank(struct json_object *g)
+{
+	bool owned = cc_json_bool(g, "isOwned");
+	const char *category = cc_json_str(g, "category");
+	const char *service = cc_json_str(g, "streamServiceType");
+	int rank = owned ? 100 : 0;
+	if(strcmp(category, "owned") == 0)
+		rank += 40;
+	else if(strcmp(category, "streamable") == 0)
+		rank += 20;
+	if(owned && strcmp(service, "pscloud") == 0)
+		rank += 10;
+	if(cc_json_int(g, "feature_type") != 1)
+		rank += 2; // full game over a trial wrapper for the same exact SKU
+	if(cc_json_bool(g, "plusCatalog"))
+		rank += 1;
+	return rank;
+}
+
+// Returns a NEW array and consumes no references from games.
+static struct json_object *dedupe_contract_product_ids(struct json_object *games)
+{
+	struct json_object *out = json_object_new_array();
+	struct json_object *index = json_object_new_object();
+	size_t n = json_object_array_length(games);
+	for(size_t i = 0; i < n; i++)
+	{
+		struct json_object *candidate = json_object_array_get_idx(games, i);
+		const char *pid = cc_json_str(candidate, "productId");
+		int existing_idx = *pid ? idx_get(index, pid) : -1;
+		if(existing_idx < 0)
+		{
+			if(*pid)
+				idx_put(index, pid, (int)json_object_array_length(out));
+			json_object_array_add(out, json_object_get(candidate));
+			continue;
+		}
+
+		struct json_object *existing = json_object_array_get_idx(out, (size_t)existing_idx);
+		bool plus_catalog = cc_json_bool(existing, "plusCatalog")
+			|| cc_json_bool(candidate, "plusCatalog");
+		if(contract_game_rank(candidate) > contract_game_rank(existing))
+		{
+			cc_json_set_bool(candidate, "plusCatalog", plus_catalog);
+			json_object_array_put_idx(out, (size_t)existing_idx, json_object_get(candidate));
+		}
+		else
+		{
+			cc_json_set_bool(existing, "plusCatalog", plus_catalog);
+		}
+	}
+	json_object_put(index);
+	json_object_array_sort(out, sort_owned_then_name);
+	return out;
+}
+
 // Returns a NEW array (caller owns). browse and owned are borrowed.
 static struct json_object *merge_owned_into_browse(struct json_object *browse,
                                                    struct json_object *owned_cross_ref,
@@ -1349,6 +1409,14 @@ struct json_object *cc_assemble_unified_catalog(ChiakiLog *log, const CCAssemble
 		if(*store)
 			cc_json_set_str(g, "storeProductId", store);
 	}
+
+	// Ownership stamping can converge formerly distinct source ids onto one canonical
+	// productId. Enforce the public contract's uniqueness invariant after every routing
+	// and category field has been computed, then invalidate pre-v4 caches via the schema.
+	struct json_object *deduped = dedupe_contract_product_ids(games);
+	json_object_put(games);
+	games = deduped;
+	n = json_object_array_length(games);
 
 	// 7. envelope
 	struct json_object *out = json_object_new_object();

--- a/lib/src/cloudcatalog_unified.c
+++ b/lib/src/cloudcatalog_unified.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
 //
 // Unified catalog orchestrator + public API. Mirrors the Qt fetchUnifiedCatalog
-// chain: native APOLLOROOT probe -> (public fallback | expired-warning) ->
+// chain: native APOLLOROOT probe -> (public PS3 Classics fallback | expired-warning) ->
 // imagic 6-list -> owned entitlements -> cross-reference -> assemble. Cache keys
 // (unified_catalog_v3 [contract schema; was v2 pre-migration], ps5_cloud_catalog_v6,
 // ps5_cloud_library) are shared across platforms so files stay byte-comparable, and

--- a/lib/src/cloudcatalog_unified.c
+++ b/lib/src/cloudcatalog_unified.c
@@ -199,8 +199,12 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_cloudcatalog_fetch_unified(
 			account_country_from_locale(locale, cc, sizeof(cc));
 		bool fallback_complete = true;
 		apollo = cc_fetch_apollo_fallback(log, cc, &fallback_complete);
-		snprintf(fallback_region, sizeof(fallback_region), "%s", cc_classics_store_country(cc));
-		CHIAKI_LOGI(log, "[UNIFIED] resolvedStoreCountry=%s (fallback cc_classics)", fallback_region);
+		// Preserve the account country for modern PS4 product resolution. The
+		// cloud-session layer maps only legacy PS3 ids to the regional US/GB
+		// Classics store; using that Classics country for every title makes modern
+		// CUSA products disappear (for example HU/en products 404 in GB/en).
+		snprintf(fallback_region, sizeof(fallback_region), "%s", cc);
+		CHIAKI_LOGI(log, "[UNIFIED] resolvedStoreCountry=%s (fallback account country)", fallback_region);
 		// Only a definitive REGION_UNSUPPORTED (completed 4xx) may be cached: a FATAL
 		// (transport failure / 5xx anywhere in the native probe) means a native-capable
 		// account could be looking at the degraded fallback, so serve it for this

--- a/lib/src/cloudsession_internal.h
+++ b/lib/src/cloudsession_internal.h
@@ -69,6 +69,21 @@ struct json_object; // json-c, forward-declared so this header needs no umbrella
 bool km_pick_fullgame_id(struct json_object *sku, bool require_title,
 	const char *title_id, char *out_id, size_t out_sz, ChiakiLog *log);
 
+/** Pick a streaming reservation (license_type 4 or an explicit "*GS" package). */
+bool km_pick_streaming_id(struct json_object *sku, char *out_id, size_t out_sz);
+
+/**
+ * Resolve the store path for a PSNOW product. Modern CUSA/PPSA ids stay in the
+ * account store; legacy PS3 Classics ids use the matching US/GB Apollo family.
+ * Exposed so the unit suite can protect the regional routing distinction.
+ */
+void km_resolve_store_locale(const char *game_identifier,
+	const char *account_country, const char *account_lang,
+	char *out_country, size_t country_sz, char *out_lang, size_t lang_sz);
+
+/** True only when a foreign-catalog legacy Classic cannot use account checkout. */
+bool km_should_skip_acquire(const char *game_identifier, bool catalog_is_foreign);
+
 /**
  * Kamaji session flow (PSNOW): 0.5b anonymous OAuth -> 0.5c anonymous session
  * -> 0.5d productId->entitlementId (uses store_country/store_lang) -> 0.5e

--- a/lib/src/cloudsession_kamaji.c
+++ b/lib/src/cloudsession_kamaji.c
@@ -199,8 +199,11 @@ static ChiakiErrorCode km_step0_5c_anon_session(KamajiCtx *c, const char *anon_c
 	return CHIAKI_ERR_SUCCESS;
 }
 
-// Pick a streaming entitlement (license_type==4) from one sku; returns true if found.
-static bool km_pick_streaming(KamajiCtx *c, struct json_object *sku)
+// Sony normally marks streaming reservations license_type 4, but some live rows
+// (notably Bloodborne in HU/en) expose the PS4GS reservation as license_type 0.
+// The package suffix is the authoritative fallback: GS is the streaming package,
+// while GD is the downloadable full game.
+bool km_pick_streaming_id(struct json_object *sku, char *out_id, size_t out_sz)
 {
 	struct json_object *ents = cc_json_arr(sku, "entitlements");
 	if(!ents) return false;
@@ -208,18 +211,26 @@ static bool km_pick_streaming(KamajiCtx *c, struct json_object *sku)
 	for(size_t i = 0; i < n; i++)
 	{
 		struct json_object *ent = json_object_array_get_idx(ents, i);
-		if(cc_json_int(ent, "license_type") == 4)
+		const char *pkg = cc_json_str(ent, "packageType");
+		if(cc_json_int(ent, "license_type") == 4 || cc_ends_with(pkg, "GS"))
 		{
 			const char *id = cc_json_str(ent, "id");
-			if(id && *id)
+			if(id && *id && out_id && out_sz > 0)
 			{
-				snprintf(c->entitlement_id, sizeof(c->entitlement_id), "%s", id);
-				snprintf(c->streaming_sku, sizeof(c->streaming_sku), "%s", cc_json_str(sku, "id"));
+				snprintf(out_id, out_sz, "%s", id);
 				return true;
 			}
 		}
 	}
 	return false;
+}
+
+static bool km_pick_streaming(KamajiCtx *c, struct json_object *sku)
+{
+	if(!km_pick_streaming_id(sku, c->entitlement_id, sizeof(c->entitlement_id)))
+		return false;
+	snprintf(c->streaming_sku, sizeof(c->streaming_sku), "%s", cc_json_str(sku, "id"));
+	return true;
 }
 
 // PS Plus catalog fallback: a full-game digital entitlement ("*GD"); optionally
@@ -257,11 +268,41 @@ static bool km_pick_fullgame(KamajiCtx *c, struct json_object *sku, bool require
 	return true;
 }
 
+static bool km_is_legacy_classic_id(const char *game_identifier)
+{
+	const char *id = game_identifier ? game_identifier : "";
+	return !cc_contains(id, "CUSA") && !cc_contains(id, "PPSA");
+}
+
+bool km_should_skip_acquire(const char *game_identifier, bool catalog_is_foreign)
+{
+	return catalog_is_foreign && km_is_legacy_classic_id(game_identifier);
+}
+
+void km_resolve_store_locale(const char *game_identifier,
+	const char *account_country, const char *account_lang,
+	char *out_country, size_t country_sz, char *out_lang, size_t lang_sz)
+{
+	if(!out_country || country_sz == 0 || !out_lang || lang_sz == 0)
+		return;
+	const char *country = (account_country && *account_country) ? account_country : "US";
+	const char *lang = (account_lang && *account_lang) ? account_lang : "en";
+	if(km_is_legacy_classic_id(game_identifier))
+	{
+		country = cc_classics_store_country(country);
+		lang = "en";
+	}
+	snprintf(out_country, country_sz, "%s", country);
+	snprintf(out_lang, lang_sz, "%s", lang);
+}
+
 static ChiakiErrorCode km_step0_5d_resolve(KamajiCtx *c, char **out_error)
 {
 	if(c->cfg->progress) c->cfg->progress("Resolving Game - Step 2 of 5", c->cfg->user);
-	const char *country = (c->cfg->store_country && *c->cfg->store_country) ? c->cfg->store_country : "US";
-	const char *lang = (c->cfg->store_lang && *c->cfg->store_lang) ? c->cfg->store_lang : "en";
+	char country[8], lang[8];
+	km_resolve_store_locale(c->cfg->game_identifier,
+		c->cfg->store_country, c->cfg->store_lang,
+		country, sizeof(country), lang, sizeof(lang));
 	// Percent-encode the id before splicing it into the path: a no-op for real
 	// product ids ([A-Z0-9-_]), but a corrupted catalog entry containing ?/#//
 	// must not be able to rewrite the request.
@@ -602,9 +643,13 @@ static ChiakiErrorCode km_step0_5e_check_acquire(KamajiCtx *c, char **out_error)
 	if(status == 200) { CHIAKI_LOGI(c->log, "[KAMAJI] entitlement already owned"); return CHIAKI_ERR_SUCCESS; }
 	if(status == 404)
 	{
-		if(c->cfg->catalog_is_foreign)
+		// Region-group fallback is required only for legacy PS3 Classics, where
+		// accounts such as HU have no pcnow checkout storefront. Modern CUSA/PPSA
+		// titles still require the normal free acquisition in their account store;
+		// skipping it makes Gaikai reject the reservation as unauthorized.
+		if(km_should_skip_acquire(c->cfg->game_identifier, c->cfg->catalog_is_foreign))
 		{
-			CHIAKI_LOGI(c->log, "[KAMAJI] entitlement 404, fallback region -> skip acquire, let Gaikai validate");
+			CHIAKI_LOGI(c->log, "[KAMAJI] entitlement 404, legacy Classics fallback -> skip acquire, let Gaikai validate");
 			return CHIAKI_ERR_SUCCESS;
 		}
 		return km_checkout_acquire(c, out_error);

--- a/test/cloudcatalog_merge.c
+++ b/test/cloudcatalog_merge.c
@@ -147,7 +147,7 @@ static MunitResult test_crossbuy_and_trial(const MunitParameter p[], void *data)
 	munit_assert_true(cc_json_bool(track, "isOwned"));
 	munit_assert_string_equal(cc_json_str(track, "category"), "owned");
 	munit_assert_string_equal(cc_json_str(track, "serviceType"), "pscloud");
-	// pscloud owned streams the entitlement's own id
+	// Ordinary pscloud ownership streams through its entitlement id.
 	munit_assert_string_equal(cc_json_str(track, "streamIdentifier"), "PPSA-TRACK-ENT");
 
 	json_object_put(env);
@@ -260,6 +260,53 @@ static MunitResult test_owned_psnow_canonical_entitlement(const MunitParameter p
 
 	json_object_put(env);
 	json_object_put(owned);
+	return MUNIT_OK;
+}
+
+// A disc-upgrade rescue explicitly launches through its replacement product id.
+// Ordinary PS5 ownership stays entitlement-first to preserve known-good routes.
+static MunitResult test_owned_pscloud_disc_rescue_identifier(const MunitParameter p[], void *data)
+{
+	(void)p; (void)data;
+	struct json_object *browse = parse(
+		"[{\"productId\":\"EP9000-PPSA01521_00-FORBIDDENWESTPS5\","
+		"\"name\":\"Horizon Forbidden West\",\"conceptId\":1001,"
+		"\"device\":[\"PS5\"],\"streamingSupported\":true},"
+		"{\"productId\":\"EP9000-PPSA01411_00-MARVELSSPIDERMAN\","
+		"\"name\":\"Marvel's Spider-Man Remastered\",\"conceptId\":1002,"
+		"\"device\":[\"PS5\"],\"streamingSupported\":true}]");
+	struct json_object *raw_owned = parse(
+		"[{\"id\":\"EP9000-PPSA01521_00-FORBIDDENWESTPS5\","
+		"\"product_id\":\"EP9000-PPSA01521_00-FORBIDDENWESTPS5\","
+		"\"feature_type\":5,\"game_meta\":{\"name\":\"Horizon Forbidden West\"},"
+		"\"entitlement_attributes\":[{\"platform_id\":\"ps5\"}]},"
+		"{\"id\":\"EP9000-PPSA17903_00-HFWCE00000000000\","
+		"\"product_id\":\"EP9000-PPSA17903_00-HFWCE00000000000\","
+		"\"feature_type\":3,\"game_meta\":{\"name\":\"Horizon Forbidden West\"},"
+		"\"entitlement_attributes\":[{\"platform_id\":\"ps5\"}]},"
+		"{\"id\":\"EP9000-PPSA01411_00-MARVELSSPIDERMAN00\","
+		"\"product_id\":\"EP9000-PPSA01411_00-MARVELSSPIDERMAN\","
+		"\"feature_type\":3,\"game_meta\":{\"name\":\"Marvel's Spider-Man Remastered\"},"
+		"\"entitlement_attributes\":[{\"platform_id\":\"ps5\"}]}]");
+	struct json_object *owned = cc_build_owned_cross_ref(get_test_log(),
+		NULL, browse, NULL, NULL, raw_owned, NULL);
+	munit_assert_int((int)json_object_array_length(owned), ==, 2);
+	CCAssembleInput in = { 0 };
+	in.imagic_browse = browse;
+	in.owned_cross_ref = owned;
+	in.native_mode = false;
+	struct json_object *env = cc_assemble_unified_catalog(get_test_log(), &in);
+	struct json_object *games = games_of(env);
+	munit_assert_string_equal(cc_json_str(find_pid(games,
+		"EP9000-PPSA17903_00-HFWCE00000000000"), "streamIdentifier"),
+		"EP9000-PPSA17903_00-HFWCE00000000000");
+	munit_assert_string_equal(cc_json_str(find_pid(games,
+		"EP9000-PPSA01411_00-MARVELSSPIDERMAN"), "streamIdentifier"),
+		"EP9000-PPSA01411_00-MARVELSSPIDERMAN00");
+	json_object_put(env);
+	json_object_put(browse);
+	json_object_put(owned);
+	json_object_put(raw_owned);
 	return MUNIT_OK;
 }
 
@@ -429,6 +476,7 @@ MunitTest tests_cloudcatalog_merge[] = {
 	{ "/crossbuy_sku_sibling", test_crossbuy_sku_sibling, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/duplicate_product_id_after_routing", test_duplicate_product_id_after_routing, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/owned_psnow_canonical_entitlement", test_owned_psnow_canonical_entitlement, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/owned_pscloud_disc_rescue_identifier", test_owned_pscloud_disc_rescue_identifier, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/sort_and_envelope", test_sort_and_envelope, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/cloud_language_helpers", test_cloud_language_helpers, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/parse_container_store_locale", test_parse_container_store_locale, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },

--- a/test/cloudcatalog_merge.c
+++ b/test/cloudcatalog_merge.c
@@ -351,6 +351,27 @@ static MunitResult test_parse_container_store_locale(const MunitParameter p[], v
 	return MUNIT_OK;
 }
 
+// Public fallback must walk the PS3 child container, not APOLLOROOT. The root
+// contains category links only, so filtering it for products produces zero games.
+static MunitResult test_classics_region_containers(const MunitParameter p[], void *data)
+{
+	(void)p; (void)data;
+	munit_assert_string_equal(cc_classics_store_country("US"), "US");
+	munit_assert_string_equal(cc_classics_ps3_container_id("US"),
+		"STORE-MSF192018-APOLLOPS3GAMES");
+	munit_assert_string_equal(cc_classics_store_country("BR"), "US");
+	munit_assert_string_equal(cc_classics_ps3_container_id("BR"),
+		"STORE-MSF192018-APOLLOPS3GAMES");
+
+	munit_assert_string_equal(cc_classics_store_country("HU"), "GB");
+	munit_assert_string_equal(cc_classics_ps3_container_id("HU"),
+		"STORE-MSF192014-APOLLOPS3");
+	munit_assert_string_equal(cc_classics_store_country("JP"), "GB");
+	munit_assert_string_equal(cc_classics_ps3_container_id("JP"),
+		"STORE-MSF192014-APOLLOPS3");
+	return MUNIT_OK;
+}
+
 static MunitResult test_stable_key(const MunitParameter params[], void *user)
 {
 	(void)params; (void)user;
@@ -374,6 +395,7 @@ MunitTest tests_cloudcatalog_merge[] = {
 	{ "/sort_and_envelope", test_sort_and_envelope, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/cloud_language_helpers", test_cloud_language_helpers, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/parse_container_store_locale", test_parse_container_store_locale, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/classics_region_containers", test_classics_region_containers, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/stable_key", test_stable_key, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };

--- a/test/cloudcatalog_merge.c
+++ b/test/cloudcatalog_merge.c
@@ -196,6 +196,37 @@ static MunitResult test_crossbuy_sku_sibling(const MunitParameter p[], void *dat
 	return MUNIT_OK;
 }
 
+// Ownership stamping can make two source rows converge on the same canonical
+// productId. The contract must emit one card, preferring the directly streamable
+// owned pscloud route over the legacy psnow wrapper. Android used to crash as soon
+// as both cards were laid out because productId backed RecyclerView stable IDs.
+static MunitResult test_duplicate_product_id_after_routing(const MunitParameter p[], void *data)
+{
+	(void)p; (void)data;
+	struct json_object *browse = parse(
+		"[{\"productId\":\"EP-CUSA-DUP_00\",\"name\":\"Duplicate\",\"conceptId\":700,\"device\":[\"PS5\"],\"streamingSupported\":true,\"serviceType\":\"psnow\",\"isOwned\":true,\"plusCatalog\":true},"
+		" {\"productId\":\"EP-CUSA-DUP_00\",\"name\":\"Duplicate\",\"conceptId\":700,\"device\":[\"PS5\"],\"streamingSupported\":true,\"serviceType\":\"pscloud\",\"isOwned\":true}]");
+
+	CCAssembleInput in = { 0 };
+	in.imagic_browse = browse;
+	in.native_mode = false;
+	in.fallback_region = "";
+
+	struct json_object *env = cc_assemble_unified_catalog(get_test_log(), &in);
+	struct json_object *games = games_of(env);
+
+	munit_assert_int(count_pid(games, "EP-CUSA-DUP_00"), ==, 1);
+	struct json_object *game = find_pid(games, "EP-CUSA-DUP_00");
+	munit_assert_not_null(game);
+	munit_assert_string_equal(cc_json_str(game, "category"), "owned");
+	munit_assert_string_equal(cc_json_str(game, "streamServiceType"), "pscloud");
+	munit_assert_true(cc_json_bool(game, "plusCatalog"));
+
+	json_object_put(env);
+	json_object_put(browse);
+	return MUNIT_OK;
+}
+
 // owned rows sort before non-owned; envelope carries schema + counts.
 static MunitResult test_sort_and_envelope(const MunitParameter p[], void *data)
 {
@@ -339,6 +370,7 @@ MunitTest tests_cloudcatalog_merge[] = {
 	{ "/device_based_ps5", test_device_based_ps5, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/crossbuy_and_trial", test_crossbuy_and_trial, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/crossbuy_sku_sibling", test_crossbuy_sku_sibling, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/duplicate_product_id_after_routing", test_duplicate_product_id_after_routing, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/sort_and_envelope", test_sort_and_envelope, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/cloud_language_helpers", test_cloud_language_helpers, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/parse_container_store_locale", test_parse_container_store_locale, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },

--- a/test/cloudcatalog_merge.c
+++ b/test/cloudcatalog_merge.c
@@ -227,6 +227,42 @@ static MunitResult test_duplicate_product_id_after_routing(const MunitParameter 
 	return MUNIT_OK;
 }
 
+// Canonical full-game entitlements commonly have id == product_id. They are still
+// real owned entitlements and must reach the contract so PSNOW can use its owned
+// fast path instead of resolving a potentially stale catalog alias through pcnow.
+static MunitResult test_owned_psnow_canonical_entitlement(const MunitParameter p[], void *data)
+{
+	(void)p; (void)data;
+	struct json_object *owned = parse(
+		"[{\"id\":\"EP9000-CUSA07410_00-00000000GODOFWAR\","
+		"\"product_id\":\"EP9000-CUSA07410_00-00000000GODOFWAR\","
+		"\"productId\":\"EP9000-CUSA07410_00-00000000GODOFWAR\","
+		"\"catalogProductId\":\"EP9000-CUSA07410_00-0000000GODOFWARN\","
+		"\"name\":\"God of War\",\"serviceType\":\"psnow\","
+		"\"feature_type\":3,\"device\":[\"PS4\"]}]");
+
+	CCAssembleInput in = { 0 };
+	in.owned_cross_ref = owned;
+	in.native_mode = false;
+	in.fallback_region = "GB";
+
+	struct json_object *env = cc_assemble_unified_catalog(get_test_log(), &in);
+	struct json_object *game = find_pid(games_of(env),
+		"EP9000-CUSA07410_00-00000000GODOFWAR");
+	munit_assert_not_null(game);
+	munit_assert_true(cc_json_bool(game, "isOwned"));
+	munit_assert_string_equal(cc_json_str(game, "entitlementId"),
+		"EP9000-CUSA07410_00-00000000GODOFWAR");
+	munit_assert_string_equal(cc_json_str(game, "storeProductId"),
+		"EP9000-CUSA07410_00-00000000GODOFWAR");
+	munit_assert_string_equal(cc_json_str(game, "streamIdentifier"),
+		"EP9000-CUSA07410_00-0000000GODOFWARN");
+
+	json_object_put(env);
+	json_object_put(owned);
+	return MUNIT_OK;
+}
+
 // owned rows sort before non-owned; envelope carries schema + counts.
 static MunitResult test_sort_and_envelope(const MunitParameter p[], void *data)
 {
@@ -392,6 +428,7 @@ MunitTest tests_cloudcatalog_merge[] = {
 	{ "/crossbuy_and_trial", test_crossbuy_and_trial, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/crossbuy_sku_sibling", test_crossbuy_sku_sibling, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/duplicate_product_id_after_routing", test_duplicate_product_id_after_routing, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/owned_psnow_canonical_entitlement", test_owned_psnow_canonical_entitlement, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/sort_and_envelope", test_sort_and_envelope, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/cloud_language_helpers", test_cloud_language_helpers, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/parse_container_store_locale", test_parse_container_store_locale, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },

--- a/test/cloudsession_kamaji.c
+++ b/test/cloudsession_kamaji.c
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-AGPL-3.0-only-OpenSSL
 //
-// Offline tests for the Kamaji resolve helpers. Covers the step 0.5d full-game
-// ("*GD") fallback: when a PS Plus title's store container exposes no
-// license_type==4 streaming reservation, km_pick_fullgame_id selects the
-// full-game digital entitlement (packageType ending "GD"), title-matched first.
-// This branch is effectively unreachable with the live catalog (every sampled
-// PS4 title carries a streaming reservation), so a synthetic JSON test is the
-// only way to pin its behavior.
+// Offline tests for the Kamaji resolve helpers: streaming/full-game entitlement
+// selection and regional store routing.
 
 #include <munit.h>
 
@@ -20,6 +15,21 @@ static struct json_object *parse(const char *s)
 	struct json_object *o = json_tokener_parse(s);
 	munit_assert_not_null(o);
 	return o;
+}
+
+static MunitResult test_streaming_package_fallback(const MunitParameter p[], void *data)
+{
+	(void)p; (void)data;
+	struct json_object *sku = parse(
+		"{\"id\":\"EP9000-CUSA00207_00-BLOODBORNE0000EU-E009\",\"entitlements\":["
+		"{\"id\":\"EP9000-CUSA00207_00-BLOODBORNE0000EU\",\"license_type\":0,\"packageType\":\"PS4GD\"},"
+		"{\"id\":\"EP9000-CUSA00207_00-PSRSVD0000000000\",\"license_type\":0,\"packageType\":\"PS4GS\"}"
+		"]}");
+	char out[128] = "";
+	munit_assert_true(km_pick_streaming_id(sku, out, sizeof(out)));
+	munit_assert_string_equal(out, "EP9000-CUSA00207_00-PSRSVD0000000000");
+	json_object_put(sku);
+	return MUNIT_OK;
 }
 
 // A non-"GD" entitlement is skipped; the *GD one is chosen (packageType-driven).
@@ -82,6 +92,40 @@ static MunitResult test_gd_fallback_none(const MunitParameter p[], void *data)
 	return MUNIT_OK;
 }
 
+static MunitResult test_regional_store_routing(const MunitParameter p[], void *data)
+{
+	(void)p; (void)data;
+	char country[8], lang[8];
+
+	// Modern PS4 titles resolve in the account storefront. God of War's HU/en
+	// product exists while the same product returns 404 from the GB store.
+	km_resolve_store_locale("EP9000-CUSA07410_00-0000000GODOFWARN",
+		"HU", "en", country, sizeof(country), lang, sizeof(lang));
+	munit_assert_string_equal(country, "HU");
+	munit_assert_string_equal(lang, "en");
+
+	// Legacy Classics use one of the two Apollo id families regardless of the
+	// account storefront's own language/country path.
+	km_resolve_store_locale("EP9000-NPEA00255_00-GGODOFWARH000001",
+		"HU", "hu", country, sizeof(country), lang, sizeof(lang));
+	munit_assert_string_equal(country, "GB");
+	munit_assert_string_equal(lang, "en");
+	km_resolve_store_locale("UP9000-NPUA80490_00-LEGACYCLASSIC00",
+		"BR", "pt", country, sizeof(country), lang, sizeof(lang));
+	munit_assert_string_equal(country, "US");
+	munit_assert_string_equal(lang, "en");
+
+	// A foreign Classics catalog skips checkout only for legacy ids. Modern PS4
+	// reservations still need their free entitlement acquired before Gaikai auth.
+	munit_assert_false(km_should_skip_acquire(
+		"EP0001-CUSA00605_00-AC5GAMEPS4000001", true));
+	munit_assert_true(km_should_skip_acquire(
+		"EP9000-NPEA00255_00-GGODOFWARH000001", true));
+	munit_assert_false(km_should_skip_acquire(
+		"EP9000-NPEA00255_00-GGODOFWARH000001", false));
+	return MUNIT_OK;
+}
+
 static bool always_cancelled(void *user)
 {
 	(void)user;
@@ -108,9 +152,11 @@ static MunitResult test_cancelled_before_start(const MunitParameter p[], void *d
 }
 
 MunitTest tests_cloudsession_kamaji[] = {
+	{ "/streaming_package_fallback", test_streaming_package_fallback, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/gd_fallback_picks_gd", test_gd_fallback_picks_gd, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/gd_fallback_title_match", test_gd_fallback_title_match, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/gd_fallback_none", test_gd_fallback_none, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
+	{ "/regional_store_routing", test_regional_store_routing, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ "/cancelled_before_start", test_cancelled_before_start, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL },
 	{ NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
 };


### PR DESCRIPTION
Hi I reapplied some of my earlier fixes, now in the shared C library. Other regions should still be tested to make sure they are not regressed. These are the games I confirmed working:

Game | Platform | Coverage / entitlement case
-- | -- | --
God of War (2018) | PS4 | Canonical owned PS4 entitlement
God of War: Ascension | PS3 | PS3 Classic catalog route
Bloodborne | PS4 | Owned PS4 entitlement
Assassin’s Creed Unity | PS4 | Owned PS4 entitlement
Trials of the Blood Dragon | PS4 | Owned PS4 entitlement
Ratchet & Clank: A Crack in Time | PS3 | PS3 Classic catalog route
Trine 4 | PS4 | PS4 catalog/entitlement route
Uncharted: The Nathan Drake Collection | PS4 | PS4 bundle entitlement
Uncharted: Legacy of Thieves Collection | PS5 | PS5 collection/upgrade entitlement
Death Stranding | PS4 | PS4 edition
Syphon Filter | Classic | Classic/cross-platform entitlement
Ratchet & Clank: Rift Apart | PS5 | Standard owned PS5 entitlement
Marvel’s Spider-Man Remastered | PS5 | PS5 wrapper/cross-buy entitlement
Fortnite | PS5 | Free-to-play/cross-generation entitlement
Death Stranding Director’s Cut | PS5 | Separate PS5 edition
Horizon Forbidden West | PS5 | Disc-upgrade rescue using replacement product ID
Horizon Zero Dawn Remastered | PS5 | Supplement-only owned entitlement