### PR TITLE
flatpak: sync mirror manifest pin to 2.11.4

### DIFF
--- a/scripts/flatpak/io.github.ForWard_Technologies_LLC.Pylux.yml
+++ b/scripts/flatpak/io.github.ForWard_Technologies_LLC.Pylux.yml
@@ -129,4 +129,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/ForWard-Technologies-LLC/Pylux.git
-        commit: 7cb1686c76e7e6df8d85288bf0eb87131d1e1237
+        commit: 3b2265771d516928d5eb86625b980e8090e2698e


### PR DESCRIPTION
Follow-up to #50. Syncs the in-repo reference manifest `scripts/flatpak/io.github.ForWard_Technologies_LLC.Pylux.yml` to the 2.11.4 release commit (`3b226577`).

The mirror pin was stale at `7cb1686c` (2.11.2, 2026-07-11) and had missed the 2.11.3 release entirely. No build consumes this file — Flathub builds from the manifest in its own packaging repo — but it is the reference copy that step 2 of the release process keeps in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)